### PR TITLE
feat(sorters): add mru sort

### DIFF
--- a/lua/bufferline/sorters.lua
+++ b/lua/bufferline/sorters.lua
@@ -2,7 +2,8 @@ local M = {}
 ---------------------------------------------------------------------------//
 -- Sorters
 ---------------------------------------------------------------------------//
-local fnamemodify = vim.fn.fnamemodify
+local fn = vim.fn
+local fnamemodify = fn.fnamemodify
 
 -- @param path string
 local function full_path(path)
@@ -18,6 +19,12 @@ end
 --- @param buf_b Buffer
 local function sort_by_extension(buf_a, buf_b)
   return fnamemodify(buf_a.filename, ":e") < fnamemodify(buf_b.filename, ":e")
+end
+
+--- @param buf_a Buffer
+--- @param buf_b Buffer
+local function sort_by_mru(buf_a, buf_b)
+  return fn.getbufinfo(buf_a)[1].lastused > fn.getbufinfo(buf_b)[1].lastused
 end
 
 --- @param buf_a Buffer
@@ -58,6 +65,8 @@ function M.sort_buffers(sort_by, buffers)
     table.sort(buffers, sort_by_relative_directory)
   elseif sort_by == "id" then
     table.sort(buffers, sort_by_id)
+  elseif sort_by == "mru" then
+    table.sort(buffers, sort_by_mru)
   elseif type(sort_by) == "function" then
     table.sort(buffers, sort_by)
   end

--- a/lua/bufferline/sorters.lua
+++ b/lua/bufferline/sorters.lua
@@ -24,7 +24,7 @@ end
 --- @param buf_a Buffer
 --- @param buf_b Buffer
 local function sort_by_mru(buf_a, buf_b)
-  return fn.getbufinfo(buf_a)[1].lastused > fn.getbufinfo(buf_b)[1].lastused
+  return fn.getbufinfo(buf_a.id)[1].lastused > fn.getbufinfo(buf_b.id)[1].lastused
 end
 
 --- @param buf_a Buffer


### PR DESCRIPTION
Just noticed looking at a telescope commit recently that using `bufgetinfo` you can get the `lastused` time of a buffer, this then allows a simply way to potentially sort buffers by most recently used time which is a simpler implementation than #97 