### PR TITLE
Add icon padding in buffer pick mode

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -562,8 +562,12 @@ local function add_prefix(context)
   local length = context.length
 
   if state.is_picking and buffer.letter then
-    component = hl.pick .. buffer.letter .. padding .. hl.background .. component
-    length = length + strwidth(buffer.letter) + strwidth(padding)
+    local icon_padding = ""
+    if options.show_buffer_icons and buffer.icon then
+      icon_padding = string.rep(" ", strwidth(buffer.icon) - 1)
+    end
+    component = hl.pick .. buffer.letter .. icon_padding .. padding .. hl.background .. component
+    length = length + strwidth(buffer.letter) + strwidth(icon_padding) + strwidth(padding)
   elseif options.show_buffer_icons and buffer.icon then
     local icon_highlight = highlight_icon(buffer)
     component = icon_highlight .. hl.background .. component


### PR DESCRIPTION
This PR addresses the issue I described in #192 but without exposing another obscure configuration option. Basically, I added what I am calling "icon padding" when entering buffer pick mode. This is extra padding after the buffer letter that matches the width of the buffer icon so that the component won't change width when an icon that is more than a single character is replaced by a single letter. I included some short videos of the before and after in case my explanation of the issue isn't clear. I realize this is a bit of an obscure use case so I understand if you prefer to not include this change, but given it's a very small code change I thought I would see how you felt.

### Without Padding
https://user-images.githubusercontent.com/60856003/130717983-f261150a-617e-4511-9a91-907ddf8d44b4.mp4

### With Icon Padding
https://user-images.githubusercontent.com/60856003/130717921-ae8fc3f9-e9d3-4cf0-b841-d7f69561b91c.mp4



