### PR TITLE
fix(docs): correct name for buffer id on numbers section

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -124,10 +124,10 @@ the `numbers` option. Currently this can be specified as either a string of
 in determining the appearance of this section.
 
 It is passed a table with the following keys:
-  * `raise` - a helper function to convert the passed number to superscript e.g. `raise(buffer_id)`.
-  * `lower` - a helper function to convert the passed number to subscript e.g. `lower(buffer_id)`.
+  * `raise` - a helper function to convert the passed number to superscript e.g. `raise(id)`.
+  * `lower` - a helper function to convert the passed number to subscript e.g. `lower(id)`.
   * `ordinal` - The buffer ordinal number.
-  * `buffer_id` - The buffer ID.
+  * `id` - The buffer ID.
 >
   -- For ⁸·₂
   numbers = function(opts)


### PR DESCRIPTION
Hey, hope you're doing well!

It took a few days for me to update by setup to match the recent "breaking changes" and I noticed that there was an inconsistency in the Numbers section of the docs while updating my configs so this PR aims to fix it.

Regards