### PR TITLE
Extract Buffer Functions

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -103,50 +103,6 @@ function M.restore_positions()
   end
 end
 
---- sorts buf_names in place, but doesn't add/remove any values
---- @param buf_nums number[]
---- @param sorted number[]
---- @return number[]
-local function get_updated_buffers(buf_nums, sorted)
-  if not sorted then
-    return buf_nums
-  end
-  local nums = { unpack(buf_nums) }
-  local reverse_lookup_sorted = utils.tbl_reverse_lookup(sorted)
-
-  --- a comparator that sorts buffers by their position in sorted
-  local sort_by_sorted = function(buf_id_1, buf_id_2)
-    local buf_1_rank = reverse_lookup_sorted[buf_id_1]
-    local buf_2_rank = reverse_lookup_sorted[buf_id_2]
-    if not buf_1_rank then
-      return false
-    end
-    if not buf_2_rank then
-      return true
-    end
-    return buf_1_rank < buf_2_rank
-  end
-  table.sort(nums, sort_by_sorted)
-  return nums
-end
-
----Filter the buffers to show based on the user callback passed in
----@param buf_nums integer[]
----@param callback fun(buf: integer, bufs: integer[]): boolean
----@return integer[]
-local function apply_buffer_filter(buf_nums, callback)
-  if type(callback) ~= "function" then
-    return buf_nums
-  end
-  local filtered = {}
-  for _, buf in ipairs(buf_nums) do
-    if callback(buf, buf_nums) then
-      table.insert(filtered, buf)
-    end
-  end
-  return filtered
-end
-
 ---------------------------------------------------------------------------//
 -- User commands
 ---------------------------------------------------------------------------//
@@ -1017,51 +973,23 @@ end
 --- @return string
 local function bufferline(config)
   local options = config.options
-  local buf_nums = utils.get_valid_buffers()
-  if options and options.custom_filter then
-    buf_nums = apply_buffer_filter(buf_nums, options.custom_filter)
-  end
-  buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
+
+  local buffers = require("bufferline.buffers").get_valid_buffers()
   local tabpages = require("bufferline.tabpages").get(options.separator_style, config)
 
-  if not options.always_show_bufferline then
-    if #buf_nums == 1 then
-      vim.o.showtabline = 0
-      return
-    end
+  -- Don't display bufferline if there's only one tab (unless configured to do so).
+  if not options.always_show_bufferline and #buffers == 1 then
+    vim.o.showtabline = 0
+    return
   end
 
-  local pick = require("bufferline.pick")
-  local duplicates = require("bufferline.duplicates")
-  local has_groups = config:enabled("groups")
+  -- Render the individual buffers
+  buffers = vim.tbl_map(function(buffer)
+    buffer.component, buffer.length = render_buffer(config, buffer)
+    return buffer
+  end, buffers)
 
-  pick.reset()
-  duplicates.reset()
-  ---@type Buffer[]
-  local buffers = {}
-  local all_diagnostics = require("bufferline.diagnostics").get(options)
-  local Buffer = require("bufferline.models").Buffer
-  for i, buf_id in ipairs(buf_nums) do
-    local buf = Buffer:new({
-      path = vim.fn.bufname(buf_id),
-      id = buf_id,
-      ordinal = i,
-      diagnostics = all_diagnostics[buf_id],
-      name_formatter = options.name_formatter,
-    })
-    buf.letter = pick.get(buf)
-    if has_groups then
-      buf.group = require("bufferline.groups").set_id(buf)
-    end
-    buffers[i] = buf
-  end
-
-  local deduplicated = duplicates.mark(buffers)
-  buffers = vim.tbl_map(function(buf)
-    buf.component, buf.length = render_buffer(config, buf)
-    return buf
-  end, deduplicated)
-
+  -- Render bufferline.
   return render(buffers, tabpages, config)
 end
 

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -1,0 +1,123 @@
+local utils = require("bufferline.utils")
+local Buffer = require("bufferline.models").Buffer
+local pick = require("bufferline.pick")
+local duplicates = require("bufferline.duplicates")
+local diagnostics = require("bufferline.diagnostics")
+local groups = require("bufferline.groups")
+
+local M = {}
+
+---Filter the buffers to show based on the user callback passed in.
+---@param buf_nums integer[]
+---@param callback fun(buf: integer, bufs: integer[]): boolean
+---@return integer[]
+local function filter_buffer_numbers(buf_nums, callback)
+  if type(callback) ~= "function" then
+    return buf_nums
+  end
+
+  local filtered = {}
+
+  for _, buf in ipairs(buf_nums) do
+    if callback(buf, buf_nums) then
+      table.insert(filtered, buf)
+    end
+  end
+
+  return filtered
+end
+
+--- Sorts buf_names in place using the provided sorted table. Doesn't add or remove any values.
+--- @param buf_nums integer[]
+--- @param sorted integer[]
+--- @return integer[]
+local function sort_buffer_numbers(buf_nums, sorted)
+  if not sorted then
+    return buf_nums
+  end
+
+  local nums = { unpack(buf_nums) }
+  local reverse_lookup_sorted = utils.tbl_reverse_lookup(sorted)
+
+  --- a comparator that sorts buffers by their position in sorted
+  local sort_by_sorted = function(buf_id_1, buf_id_2)
+    local buf_1_rank = reverse_lookup_sorted[buf_id_1]
+    local buf_2_rank = reverse_lookup_sorted[buf_id_2]
+    if not buf_1_rank then
+      return false
+    end
+    if not buf_2_rank then
+      return true
+    end
+    return buf_1_rank < buf_2_rank
+  end
+
+  table.sort(nums, sort_by_sorted)
+
+  return nums
+end
+
+--- Returns the current valid buffer numbers.
+---@param custom_filter fun(buf: integer, bufs: integer[]): boolean
+---@param custom_sort integer[]
+---@return integer[]
+local get_valid_buffer_numbers = function(custom_filter, custom_sort)
+  local buf_nums = vim.api.nvim_list_bufs()
+
+  buf_nums = filter_buffer_numbers(buf_nums, custom_filter)
+  buf_nums = sort_buffer_numbers(buf_nums, custom_sort)
+
+  -- NOTE: In Lua in order to iterate an array, indices should
+  -- not contain gaps otherwise "ipairs" will stop at the first gap
+  -- i.e the indices should be contiguous
+  local index = 0
+  local valid_bufs = {}
+
+  for _, buf in ipairs(buf_nums) do
+    if M.is_valid(buf) then
+      index = index + 1
+      valid_bufs[index] = buf
+    end
+  end
+
+  return valid_bufs
+end
+
+--- Returns the current valid buffers.
+--- @param config BufferlineConfig
+--- @return Buffer[]
+function M.get_valid_buffers(config)
+  local options = config.options or {}
+  local has_groups = config:enabled("groups")
+  pick.reset()
+  duplicates.reset()
+
+  local buffer_numbers = get_valid_buffer_numbers(options.custom_filter, options.custom_sort)
+
+  --- @type Buffer[]
+  local buffers = {}
+
+  local all_diagnostics = diagnostics.get(options)
+
+  for i, buffer_id in ipairs(buffer_numbers) do
+    local buffer = Buffer:new({
+      path = vim.fn.bufname(buffer_id),
+      id = buffer_id,
+      ordinal = i,
+      diagnostics = all_diagnostics[buffer_id],
+      name_formatter = options.name_formatter,
+    })
+
+    buffer.letter = pick.get(buffer)
+
+    if has_groups then
+      buffer.group = groups.set_id(buffer)
+    end
+
+    buffers[i] = buffer
+  end
+
+  return duplicates.mark(buffers)
+end
+
+return M

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -205,24 +205,6 @@ function M.is_valid(buf_num)
   return vim.bo[buf_num].buflisted and exists
 end
 
---- @param bufs table | nil
-function M.get_valid_buffers(bufs)
-  local buf_nums = bufs or vim.api.nvim_list_bufs()
-  local valid_bufs = {}
-
-  -- NOTE: In lua in order to iterate an array, indices should
-  -- not contain gaps otherwise "ipairs" will stop at the first gap
-  -- i.e the indices should be contiguous
-  local count = 0
-  for _, buf in ipairs(buf_nums) do
-    if M.is_valid(buf) then
-      count = count + 1
-      valid_bufs[count] = buf
-    end
-  end
-  return valid_bufs
-end
-
 ---Print an error message to the commandline
 ---@param msg string
 function M.echoerr(msg)


### PR DESCRIPTION
This is the first PR, primarily based around extracting the buffer logic from the `bufferline` function. Hopefully, this will pave the way for an easier transition to a `Tabpage` model.

I wanted to get early feedback on the direction of this work before polishing it off, so I opened this as a draft PR. Also, I’m still getting used to a Lua environment and development, so please let me know if I’m making any obvious mistakes with the language.

The main focus of this PR is a new `get_valid_buffers` function. This should return complete instances of `TabView` that are ready to be rendered. In the future, I plan on adding a `get_valid_tabpages` function that does the same thing, but with tabpages.

* How did you set up your environment for local Lua plugin development. I’m using LunarVim, which uses Packer, and I just added my local directory to the plugins table like this: `{ "~/Development/open-source/bufferline.nvim" }`. I’m not 100% sure that Packer is actually picking that up though. Did you do something similar, or is there a better way to handle this?
* How do I run the specs? I didn’t see any documentation on the framework used, but maybe I missed it somewhere.
* Should `tabpage` become a property of `TabView` rather than being an extra table parameter passed into `render`? This property obviously wouldn’t apply to `Tabpage`s, but it would apply to `Buffer` instances. This would simplify the interface for `render`, making it easier to include `Tabpage`s.
* What would you like to see done in terms of testing for this functionality. I tried not to change anything about how it works (mainly just extracting and moving bits around.
* How much needs to be changed in `render_buffer`? Would this function as a generic `render_tab_view` function as-is, or is it too specific to buffers?