### PR TITLE
fix(offset): Search winhl in reverse order when guessing hl.

### DIFF
--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -66,8 +66,8 @@ local function guess_window_highlight(win_id, attribute, match)
     return
   end
   local parts = vim.split(hl, ",")
-  for _, part in ipairs(parts) do
-    local grp, hl_name = unpack(vim.split(part, ":"))
+  for i = #parts, 1, -1 do
+    local grp, hl_name = unpack(vim.split(parts[i], ":"))
     if grp and grp:match(match) then
       return hl_name
     end


### PR DESCRIPTION
When `:h 'winhl'` contains multiple entries for the same hl-group, vim will
use the last one. Thus, we should search the winhl entries in reverse
order when we are trying to guess the offset hl.

Example:
- The value of `'winhl'` is `Normal:Foo,Normal:Bar,Normal:Baz`.
- Vim will in this case link `Normal` to `Baz`, but the current implementation will guess `Foo`.