### PR TITLE
feat: Add hint diagnostic highlight

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -388,6 +388,8 @@ local function get_buffer_highlight(buffer, config)
     hl.warning_diagnostic = h.warning_diagnostic_selected.hl
     hl.info = h.info_selected.hl
     hl.info_diagnostic = h.info_diagnostic_selected.hl
+    hl.hint = h.hint_selected.hl
+    hl.hint_diagnostic = h.hint_diagnostic_selected.hl
     hl.close_button = h.close_button_selected.hl
   elseif buffer:visible() then
     hl.background = h.buffer_visible.hl
@@ -403,6 +405,8 @@ local function get_buffer_highlight(buffer, config)
     hl.warning_diagnostic = h.warning_diagnostic_visible.hl
     hl.info = h.info_visible.hl
     hl.info_diagnostic = h.info_diagnostic_visible.hl
+    hl.hint = h.hint_visible.hl
+    hl.hint_diagnostic = h.hint_diagnostic_visible.hl
     hl.close_button = h.close_button_visible.hl
   else
     hl.background = h.background.hl
@@ -418,6 +422,8 @@ local function get_buffer_highlight(buffer, config)
     hl.warning_diagnostic = h.warning_diagnostic.hl
     hl.info = h.info.hl
     hl.info_diagnostic = h.info_diagnostic.hl
+    hl.hint = h.hint.hl
+    hl.hint_diagnostic = h.hint_diagnostic.hl
     hl.close_button = h.close_button.hl
   end
 

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -223,6 +223,7 @@ local function derive_colors()
   local error_hl = nightly and "DiagnosticError" or "LspDiagnosticsDefaultError"
   local warning_hl = nightly and "DiagnosticWarn" or "LspDiagnosticsDefaultWarning"
   local info_hl = nightly and "DiagnosticInfo" or "LspDiagnosticsDefaultInformation"
+  local hint_hl = nightly and "DiagnosticHint" or "LspDiagnosticsDefaultHint"
 
   local error_fg = hex({
     name = error_hl,
@@ -240,6 +241,12 @@ local function derive_colors()
     name = info_hl,
     attribute = "fg",
     fallback = { name = "Normal", attribute = "fg" },
+  })
+
+  local hint_fg = hex({
+    name = hint_hl,
+    attribute = "fg",
+    fallback = { name = "SpecialComment", attribute = "fg" },
   })
 
   local tabline_sel_bg = hex({
@@ -269,6 +276,7 @@ local function derive_colors()
   -- diagnostic colors by default are a few shades darker
   local normal_diagnostic_fg = shade(normal_fg, diagnostic_shading)
   local comment_diagnostic_fg = shade(comment_fg, diagnostic_shading)
+  local hint_diagnostic_fg = shade(hint_fg, diagnostic_shading)
   local info_diagnostic_fg = shade(info_fg, diagnostic_shading)
   local warning_diagnostic_fg = shade(warning_fg, diagnostic_shading)
   local error_diagnostic_fg = shade(error_fg, diagnostic_shading)
@@ -339,6 +347,36 @@ local function derive_colors()
       guifg = normal_diagnostic_fg,
       guibg = normal_bg,
       gui = "bold,italic",
+    },
+    hint = {
+      guifg = comment_fg,
+      guisp = hint_fg,
+      guibg = background_color,
+    },
+    hint_visible = {
+      guifg = comment_fg,
+      guibg = visible_bg,
+    },
+    hint_selected = {
+      guifg = hint_fg,
+      guibg = normal_bg,
+      gui = "bold,italic",
+      guisp = hint_fg,
+    },
+    hint_diagnostic = {
+      guifg = comment_diagnostic_fg,
+      guisp = hint_diagnostic_fg,
+      guibg = background_color,
+    },
+    hint_diagnostic_visible = {
+      guifg = comment_diagnostic_fg,
+      guibg = visible_bg,
+    },
+    hint_diagnostic_selected = {
+      guifg = hint_diagnostic_fg,
+      guibg = normal_bg,
+      gui = "bold,italic",
+      guisp = hint_diagnostic_fg,
     },
     info = {
       guifg = comment_fg,

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -246,7 +246,7 @@ local function derive_colors()
   local hint_fg = hex({
     name = hint_hl,
     attribute = "fg",
-    fallback = { name = "SpecialComment", attribute = "fg" },
+    fallback = { name = "Directory", attribute = "fg" },
   })
 
   local tabline_sel_bg = hex({

--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -6,7 +6,8 @@ local severity_name = {
   [1] = "error",
   [2] = "warning",
   [3] = "info",
-  [4] = "other",
+  [4] = "hint",
+  [5] = "other",
 }
 
 setmetatable(severity_name, {


### PR DESCRIPTION
Looks like hint level diagnostics are not explicitly set to derive hl from corresponding existing groups, so I did that. Not sure about the fallback, seems suitable though.