### PR TITLE
chore: no extra padding if numbers func returns empty string

### DIFF
--- a/lua/bufferline/numbers.lua
+++ b/lua/bufferline/numbers.lua
@@ -121,7 +121,10 @@ function M.component(context)
     return context
   end
   local number_prefix = prefix(buffer, options.numbers, options.number_style)
-  local number_component = number_prefix .. constants.padding
+  local number_component = ""
+  if number_prefix ~= "" then
+    number_component = number_prefix .. constants.padding
+  end
   component = number_component .. component
   length = length + vim.fn.strwidth(number_component)
   return context:update({ component = component, length = length })


### PR DESCRIPTION
Small buffer index padding fix - if `numbers` is a function that returns an empty string we don't need additional padding.

I am using it in the following example 
```
numbers = function(opts)                                         
  if vim.api.nvim_get_current_buf() == opts.id then return "" end
  return opts.ordinal                                            
end,                                                             
```

Before - extra padding
![image](https://user-images.githubusercontent.com/19948672/147828209-0a2d1279-bb78-44e2-bff7-4e989182273b.png)

After - no extra padding
![image](https://user-images.githubusercontent.com/19948672/147828153-3787c00c-6baf-4ab7-b21f-1082f7ede2df.png)
