### PR TITLE
fix: 0.6.1 diagnostic deprecation warning #285

### DIFF
--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -72,7 +72,8 @@ end
 
 local get_diagnostics = {
   nvim_lsp = function()
-    if is_nightly then
+    local is_get_all_deprected = utils.is_truthy(fn.has("nvim-0.6.1"))
+    if is_get_all_deprected then
       local results = {}
       local diagnostics = vim.diagnostic.get()
 

--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -72,8 +72,7 @@ end
 
 local get_diagnostics = {
   nvim_lsp = function()
-    local is_get_all_deprected = utils.is_truthy(fn.has("nvim-0.6.1"))
-    if is_get_all_deprected then
+    if utils.is_truthy(fn.has("nvim-0.6.1")) then
       local results = {}
       local diagnostics = vim.diagnostic.get()
 


### PR DESCRIPTION
This should fix #285 . Instead of checking 0.7 nightly, now just check if the version is greater than 0.6.1.