### PR TITLE
trim unnecessary (too much) front-padding in slant style buffer "tab"

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -522,7 +522,7 @@ local function add_indicator(context)
   local style = options.separator_style
 
   if buffer:current() then
-    local indicator = " "
+    local indicator = ""
     local symbol = indicator
     if not is_slant(style) then
       symbol = options.indicator_icon


### PR DESCRIPTION
When the buffer "tab" style is slant, the front of the "tab" has one extra space too much. It is unnecessary and just takes up "space" (pun intended).

Signed-off-by: David Ward <dward@redhat.com>