### PR TITLE
feat(groups.lua): add "gui" option to group label

### DIFF
--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -128,6 +128,7 @@ local function set_group_highlights(name, group, hls)
     guibg = hls.fill.guibg,
   }
   hls[fmt("%s_label", name)] = {
+    gui = hl.gui or "none",
     guifg = hls.fill.guibg,
     guibg = hl.guifg or hl.guisp or hls.group_separator.guifg,
   }


### PR DESCRIPTION
- allows for the user to specify a gui option for a group label on a per-group basis, e.g. "bold" to change name of group to bold text
    - defaults to "none" to preserve originally intended UI appearance