### PR TITLE
refactor: explicitly require the bit module

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -1,4 +1,3 @@
-local bit = require("bit")
 local constants = require("bufferline.constants")
 local utils = require("bufferline.utils")
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -1,3 +1,4 @@
+local bit = require("bit")
 local constants = require("bufferline.constants")
 local utils = require("bufferline.utils")
 

--- a/lua/bufferline/colors.lua
+++ b/lua/bufferline/colors.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local bit = require("bit")
 local fmt = string.format
 
 ---Convert a hex color to rgb


### PR DESCRIPTION
This makes the dependency explicit, limits the scope to the current file and provides faster access to the bit.* functions, too. It's good programming practice not to rely on the global variable bit being set (assuming some other part of your application has already loaded the module). The require function ensures the module is only loaded once, in any case.

Without explicit adding the line I receive:

```
lua/bufferline/colors.lua:71: attempt to index global 'bit' (a nil value)
```