### PR TITLE
perf(coc-diagnostics): use event `CocDiagnosticChange`

### DIFF
--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -93,7 +93,7 @@ local get_diagnostics = {
   coc = (function()
     local diagnostics = {}
 
-    _G.___refresh_coc_diagnostics_for_bufferline___ = function()
+    function M.refresh_coc_diagnostics()
       pcall(fn.CocActionAsync, "diagnosticList", function(err, res)
         if err ~= vim.NIL then
           return
@@ -117,7 +117,9 @@ local get_diagnostics = {
       end)
     end
 
-    vim.cmd([[autocmd User CocDiagnosticChange lua ___refresh_coc_diagnostics_for_bufferline___()]])
+    vim.cmd(
+      [[autocmd User CocDiagnosticChange lua require('bufferline.diagnostics').refresh_coc_diagnostics()]]
+    )
 
     return function()
       return diagnostics

--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -91,40 +91,36 @@ local get_diagnostics = {
   end,
 
   coc = (function()
-    local _initialized = false
-    local function _init_coc()
-      _initialized = true
+    local diagnostics = {}
 
-      vim.cmd([[
-       autocmd User CocDiagnosticChange lua pcall(vim.fn.CocActionAsync, 'diagnosticList',
-      \ function(err, res)
-      \   if err ~= vim.NIL then
-      \     return
-      \   end
-      \   res = type(res) == "table" and res or {}
-      \   local result = {}
-      \   local bufname2bufnr = {}
-      \   for _, diagnostic in ipairs(res) do
-      \     local bufname = diagnostic.file
-      \     local bufnr = bufname2bufnr[bufname]
-      \     if not bufnr then
-      \       bufnr = vim.fn.bufnr(bufname)
-      \       bufname2bufnr[bufname] = bufnr
-      \     end
-      \     if bufnr ~= -1 then
-      \       result[bufnr] = result[bufnr] or {}
-      \       table.insert(result[bufnr], { severity = diagnostic.level })
-      \     end
-      \   end
-      \ vim.g.___coc_diagnostics_for_bufferline___ = result
-      \ end)
-       ]])
+    _G.___refresh_coc_diagnostics_for_bufferline___ = function()
+      pcall(fn.CocActionAsync, "diagnosticList", function(err, res)
+        if err ~= vim.NIL then
+          return
+        end
+        res = type(res) == "table" and res or {}
+        local result = {}
+        local bufname2bufnr = {}
+        for _, diagnostic in ipairs(res) do
+          local bufname = diagnostic.file
+          local bufnr = bufname2bufnr[bufname]
+          if not bufnr then
+            bufnr = vim.fn.bufnr(bufname)
+            bufname2bufnr[bufname] = bufnr
+          end
+          if bufnr ~= -1 then
+            result[bufnr] = result[bufnr] or {}
+            table.insert(result[bufnr], { severity = diagnostic.level })
+          end
+        end
+        diagnostics = result
+      end)
     end
+
+    vim.cmd([[autocmd User CocDiagnosticChange lua ___refresh_coc_diagnostics_for_bufferline___()]])
+
     return function()
-      if not _initialized then
-        _init_coc()
-      end
-      return vim.g.___coc_diagnostics_for_bufferline___ or {}
+      return diagnostics
     end
   end)(),
 }


### PR DESCRIPTION
Coc will trigger `CocDiagnosticChange` when diagnostic status changed.
Only get diagnostics when `CocDiagnosticChange`, can avoid a lot of
unnecessary `CocActionAsync` calls.