### PR TITLE
feat(config): add themeable option

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -55,6 +55,7 @@ The available settings are: >
     require"bufferline".setup{
         options = {
             mode = "buffers", -- can also be set to "tabs" to see tabpages
+            themable = false -- whether or not the highlights for this plugin can be overriden.
             numbers = "none" | "ordinal" | "buffer_id" | "both" | function({ ordinal, id, lower, raise }): string,
             --- @deprecated, please specify numbers as a function to customize the styling
             number_style = "superscript" | "" | { "none", "subscript" }, -- buffer_id at index 1, ordinal at index 2
@@ -822,6 +823,30 @@ highlight command. See `:h highlight` .
         };
     }
 <
+
+==============================================================================
+COLORSCHEME DEVELOPMENT                                           *bufferline-colorscheme-development*
+
+Bufferline was initially developed to work without external highlight
+configuration by colorschemes. It takes default highlights from neovim and
+adapts these for it's usage. The highlight groups it uses are
+The `->` represents the fallback chain for a highlight.
+
+`Normal`
+`String`
+`DiagnosticError` -> `LspDiagnosticsDefaultError`
+`DiagnosticWarn` -> `LspDiagnosticsDefaultWarn` -> `WarningMsg`
+`DiagnosticHint` -> `LspDiagnosticsDefaultHint` -> `Directory`
+`DiagnosticInfo` -> `LspDiagnosticsDefaultInfo` -> `Normal`
+`TabLineSel` -> `WildMenu`
+
+If the above groups are correctly highlighted then bufferline should appear
+as intended where it can be i.e. sufficient contrast etc.
+
+If however a colorscheme intends to override bufferline highlight groups
+a user can set the `themable` option in their bufferline config to `true`.
+This will change bufferline's highlights to use the `default` keyword
+so they can be more easily overriden if that is the user's preference.
 
 ==============================================================================
 ISSUES							*bufferline-issues*

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -62,6 +62,7 @@ local colors = lazy.require("bufferline.colors")
 ---@field public diagnostics_update_in_insert boolean
 ---@field public offsets table[]
 ---@field public groups GroupOpts
+---@field public themable boolean
 
 ---@class BufferlineHLGroup
 ---@field guifg string
@@ -549,6 +550,7 @@ local function get_defaults()
     ---@type BufferlineOptions
     options = {
       mode = "buffers",
+      themable = true, -- whether or not bufferline highlights can be overriden externally
       numbers = "none",
       number_style = "superscript",
       buffer_close_icon = "",

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -54,10 +54,14 @@ function M.set_one(name, opts)
       table.insert(hls, fmt("%s=%s", key, value))
     end
   end
-  local success, err = pcall(vim.cmd, fmt("highlight! %s %s", name, table.concat(hls, " ")))
-  if not success then
+  local themable = require("bufferline.config").get("options").themable
+  local ok, rsp = pcall(
+    vim.cmd,
+    fmt("highlight %s %s %s", themable and "default" or "", name, table.concat(hls, " "))
+  )
+  if not ok then
     utils.notify(
-      fmt("Failed setting %s highlight, something isn't configured correctly: %s", name, err),
+      fmt("Failed setting %s  highlight, something isn't configured correctly: %s", name, rsp),
       utils.E
     )
   end


### PR DESCRIPTION
This PR will fix #320 by allowing a user to set a config option, currently `themable` which will allow highlights created by bufferline to be `default` i.e. more easily overridden by colorschemes.

It's really important to understand that by default bufferline is not intended to be themed by colorscheme authors, it was designed to derive a palette based on common highlight groups which are generally set in most colorschemes. So changing individual highlights is not advisable, but since there is some demand amongst colorscheme authors, this change will make this possible. However, I *strongly* recommend against it since the highlights are derived dynamically and so the names can change, breaking colorschemes highlights.

In general, it would be better for colorschemes to ensure all the basic nvim highlights outlined in the new help section are set and so bufferline can just continue to derive colors from those and not have individual highlights changed by colorschemes