### PR TITLE
feat: insert new buffers after current

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -23,7 +23,6 @@ local constants = lazy.require("bufferline.constants")
 local highlights = lazy.require("bufferline.highlights")
 
 local api = vim.api
-local fn = vim.fn
 local fmt = string.format
 
 local positions_key = constants.positions_key

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -187,7 +187,7 @@ end
 
 function M.handle_group_enter()
   local options = config.options
-  local _, element = commands.get_current_element_index({ include_hidden = true })
+  local _, element = commands.get_current_element_index(state, { include_hidden = true })
   if not element or not element.group then
     return
   end

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -76,8 +76,8 @@ function M.get_components(state)
   end
   buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
 
-  buffers:add_all(buf_nums)
-  local buf_ids = buffers:intersection(buf_nums)
+  buffers:add_all(buf_nums, start_index)
+  local buf_ids = buffers:replace_with_intersection(buf_nums)
 
   local has_groups = config:enabled("groups")
 

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -7,8 +7,13 @@ local groups = lazy.require("bufferline.groups")
 local config = lazy.require("bufferline.config")
 -- @module "bufferline.utils"
 local utils = lazy.require("bufferline.utils")
+-- @module "bufferline.set"
+local Set = require("bufferline.set")
 
 local M = {}
+
+---@type Set
+local buffers = Set:new()
 
 --- sorts buf_names in place, but doesn't add/remove any values
 --- @param buf_nums number[]
@@ -65,6 +70,9 @@ function M.get_components(state)
   end
   buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
 
+  buffers:add_all(buf_nums)
+  local buf_ids = buffers:intersection(buf_nums)
+
   local pick = require("bufferline.pick")
   local duplicates = require("bufferline.duplicates")
   local has_groups = config:enabled("groups")
@@ -75,7 +83,7 @@ function M.get_components(state)
   local components = {}
   local all_diagnostics = require("bufferline.diagnostics").get(options)
   local Buffer = require("bufferline.models").Buffer
-  for i, buf_id in ipairs(buffers) do
+  for i, buf_id in ipairs(buf_ids) do
     local buf = Buffer:new({
       path = vim.fn.bufname(buf_id),
       id = buf_id,

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -77,10 +77,12 @@ function M.get_components(state)
     buf_nums = apply_buffer_filter(buf_nums, options.custom_filter)
   end
   buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
-
-  local start_index = commands.get_last_accessed_index(state)
-  buffers:add_all(buf_nums, (start_index and start_index + 1 or nil))
-  local buf_ids = buffers:replace_with_intersection(buf_nums)
+  local buf_ids = buf_nums
+  if not buffers:same(buf_nums) then
+    local start_index = state.current_element_index
+    buffers:add_all(buf_nums, (start_index and start_index + 1 or nil))
+    buf_ids = buffers:replace_with_intersection(buf_nums)
+  end
 
   local has_groups = config:enabled("groups")
 

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -15,6 +15,8 @@ local pick = require("bufferline.pick")
 local duplicates = require("bufferline.duplicates")
 -- @module "bufferline.diagnostics"
 local diagnostics = require("bufferline.diagnostics")
+-- @module "bufferline.commands"
+local commands = require("bufferline.commands")
 
 local M = {}
 
@@ -76,7 +78,8 @@ function M.get_components(state)
   end
   buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
 
-  buffers:add_all(buf_nums, start_index)
+  local start_index = commands.get_last_accessed_index(state)
+  buffers:add_all(buf_nums, (start_index and start_index + 1 or nil))
   local buf_ids = buffers:replace_with_intersection(buf_nums)
 
   local has_groups = config:enabled("groups")

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -9,6 +9,12 @@ local config = lazy.require("bufferline.config")
 local utils = lazy.require("bufferline.utils")
 -- @module "bufferline.set"
 local Set = require("bufferline.set")
+-- @module "bufferline.pick"
+local pick = require("bufferline.pick")
+-- @module "bufferline.duplicates"
+local duplicates = require("bufferline.duplicates")
+-- @module "bufferline.diagnostics"
+local diagnostics = require("bufferline.diagnostics")
 
 local M = {}
 
@@ -73,15 +79,13 @@ function M.get_components(state)
   buffers:add_all(buf_nums)
   local buf_ids = buffers:intersection(buf_nums)
 
-  local pick = require("bufferline.pick")
-  local duplicates = require("bufferline.duplicates")
   local has_groups = config:enabled("groups")
 
   pick.reset()
   duplicates.reset()
   ---@type Buffer[]
   local components = {}
-  local all_diagnostics = require("bufferline.diagnostics").get(options)
+  local all_diagnostics = diagnostics.get(options)
   local Buffer = require("bufferline.models").Buffer
   for i, buf_id in ipairs(buf_ids) do
     local buf = Buffer:new({

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -72,10 +72,10 @@ function M.get_components(state)
   pick.reset()
   duplicates.reset()
   ---@type Buffer[]
-  local buffers = {}
+  local components = {}
   local all_diagnostics = require("bufferline.diagnostics").get(options)
   local Buffer = require("bufferline.models").Buffer
-  for i, buf_id in ipairs(buf_nums) do
+  for i, buf_id in ipairs(buffers) do
     local buf = Buffer:new({
       path = vim.fn.bufname(buf_id),
       id = buf_id,
@@ -85,12 +85,12 @@ function M.get_components(state)
     })
     buf.letter = pick.get(buf)
     buf.group = has_groups and groups.set_id(buf) or nil
-    buffers[i] = buf
+    components[i] = buf
   end
 
   return vim.tbl_map(function(buf)
     return ui.element(state, buf)
-  end, duplicates.mark(buffers))
+  end, duplicates.mark(components))
 end
 
 return M

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -167,6 +167,19 @@ function M.go_to(num, absolute)
   end
 end
 
+---Track and return either the current element or the last element that was current
+M.get_last_accessed_index = (function()
+  local last_index = nil
+  ---@param s BufferlineState
+  ---@param opts table
+  ---@return number
+  return function(s, opts)
+    local index = M.get_current_element_index(s, opts)
+    last_index = index or last_index
+    return last_index
+  end
+end)()
+
 ---@param s BufferlineState
 ---@param opts table
 ---@return number

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -167,19 +167,6 @@ function M.go_to(num, absolute)
   end
 end
 
----Track and return either the current element or the last element that was current
-M.get_last_accessed_index = (function()
-  local last_index = nil
-  ---@param s BufferlineState
-  ---@param opts table
-  ---@return number
-  return function(s, opts)
-    local index = M.get_current_element_index(s, opts)
-    last_index = index or last_index
-    return last_index
-  end
-end)()
-
 ---@param s BufferlineState
 ---@param opts table
 ---@return number
@@ -191,6 +178,7 @@ function M.get_current_element_index(s, opts)
   for index, item in ipairs(list) do
     local element = item:as_element()
     if element and element.id == current then
+      state.set({ current_element_index = index })
       return index, element
     end
   end

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -167,12 +167,13 @@ function M.go_to(num, absolute)
   end
 end
 
+---@param s BufferlineState
 ---@param opts table
 ---@return number
 ---@return Buffer
-function M.get_current_element_index(opts)
+function M.get_current_element_index(s, opts)
   opts = opts or { include_hidden = false }
-  local list = opts.include_hidden and state.__components or state.components
+  local list = opts.include_hidden and s.__components or s.components
   local current = get_current_element()
   for index, item in ipairs(list) do
     local element = item:as_element()
@@ -184,7 +185,7 @@ end
 
 --- @param direction number
 function M.move(direction)
-  local index = M.get_current_element_index()
+  local index = M.get_current_element_index(state)
   if not index then
     return utils.echoerr("Unable to find buffer to move, sorry")
   end
@@ -204,7 +205,7 @@ function M.move(direction)
 end
 
 function M.cycle(direction)
-  local index = M.get_current_element_index()
+  local index = M.get_current_element_index(state)
   if not index then
     return
   end
@@ -230,7 +231,7 @@ end
 ---Close all elements to the left or right of the current buffer
 ---@param direction Direction
 function M.close_in_direction(direction)
-  local index = M.get_current_element_index()
+  local index = M.get_current_element_index(state)
   if not index then
     return
   end

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -582,7 +582,7 @@ local function get_defaults()
       always_show_bufferline = true,
       persist_buffer_sort = true,
       max_prefix_length = 15,
-      sort_by = "id",
+      sort_by = "none",
       diagnostics = false,
       diagnostics_indicator = nil,
       diagnostics_update_in_insert = true,

--- a/lua/bufferline/set.lua
+++ b/lua/bufferline/set.lua
@@ -37,8 +37,8 @@ end
 
 ---@param item number
 function Set:remove(item)
-  if self.values[item] then
-    self.values[item] = nil
+  if self.values[tostring(item)] then
+    self.values[tostring(item)] = nil
     self.list = vim.tbl_filter(function(i)
       return i ~= item
     end, self.list)

--- a/lua/bufferline/set.lua
+++ b/lua/bufferline/set.lua
@@ -1,14 +1,15 @@
 ---@class Set
 ---@field private values table<string, number>
+---@field private list number[]
 local Set = {}
 
 ---@param list integer[]
 ---@return Set
 function Set:new(list)
   list = list or {}
-  local set = { values = {} }
-  for index, l in ipairs(list) do
-    set.values[tostring(l)] = index
+  local set = { values = {}, list = list }
+  for _, l in ipairs(list) do
+    set.values[tostring(l)] = true
   end
   setmetatable(set, self)
   self.__index = self
@@ -18,8 +19,9 @@ end
 ---@param item number
 ---@param index number
 function Set:add(item, index)
-  if not self.values[item] then
-    self.values[tostring(item)] = index
+  if not self.values[tostring(item)] then
+    self.values[tostring(item)] = true
+    table.insert(self.list, index or #self.list + 1, item)
   end
 end
 
@@ -29,26 +31,30 @@ function Set:has(item)
   return self.values[tostring(item)] ~= nil
 end
 
+function Set:size()
+  return #self.list
+end
+
 ---@param item number
 function Set:remove(item)
   if self.values[item] then
     self.values[item] = nil
+    self.list = vim.tbl_filter(function(i)
+      return i ~= item
+    end, self.list)
   end
 end
 
 ---@return number[]
 function Set:get_all()
-  local result = {}
-  for key, value in pairs(self.values) do
-    table.insert(result, value, tonumber(key))
-  end
-  return result
+  return self.list
 end
 
 ---@param list number[]
-function Set:add_all(list)
-  for index, l in ipairs(list) do
-    self:add(l, #self.values + index)
+---@param insertion_index number?
+function Set:add_all(list, insertion_index)
+  for _, item in ipairs(list) do
+    self:add(item, insertion_index)
   end
 end
 
@@ -57,13 +63,19 @@ end
 function Set:intersection(list)
   local result = {}
   local set_b = Set:new(list)
-  local items = self:get_all()
-  for _, item in ipairs(items) do
+  for _, item in ipairs(self.list) do
     if set_b:has(item) then
       table.insert(result, item)
     end
   end
-  return result
+  return result, set_b
+end
+
+function Set:replace_with_intersection(list)
+  local intersect, set_b = self:intersection(list)
+  self.list = intersect
+  self.values = set_b.values
+  return self.list
 end
 
 return Set

--- a/lua/bufferline/set.lua
+++ b/lua/bufferline/set.lua
@@ -35,6 +35,13 @@ function Set:size()
   return #self.list
 end
 
+---compare whether the underlying list in the set is the same as that of the list passed in
+---@param list number[]
+---@return boolean
+function Set:same(list)
+  return table.concat(self.list) == table.concat(list)
+end
+
 ---@param item number
 function Set:remove(item)
   if self.values[tostring(item)] then

--- a/lua/bufferline/set.lua
+++ b/lua/bufferline/set.lua
@@ -1,0 +1,69 @@
+---@class Set
+---@field private values table<string, number>
+local Set = {}
+
+---@param list integer[]
+---@return Set
+function Set:new(list)
+  list = list or {}
+  local set = { values = {} }
+  for index, l in ipairs(list) do
+    set.values[tostring(l)] = index
+  end
+  setmetatable(set, self)
+  self.__index = self
+  return set
+end
+
+---@param item number
+---@param index number
+function Set:add(item, index)
+  if not self.values[item] then
+    self.values[tostring(item)] = index
+  end
+end
+
+---@param item number
+---@return boolean
+function Set:has(item)
+  return self.values[tostring(item)] ~= nil
+end
+
+---@param item number
+function Set:remove(item)
+  if self.values[item] then
+    self.values[item] = nil
+  end
+end
+
+---@return number[]
+function Set:get_all()
+  local result = {}
+  for key, value in pairs(self.values) do
+    table.insert(result, value, tonumber(key))
+  end
+  return result
+end
+
+---@param list number[]
+function Set:add_all(list)
+  for index, l in ipairs(list) do
+    self:add(l, #self.values + index)
+  end
+end
+
+---The list of items that the set has in common with the list
+---@param list number[]
+function Set:intersection(list)
+  local result = {}
+  local set_b = Set:new(list)
+  local items = self:get_all()
+  for _, item in ipairs(items) do
+    if set_b:has(item) then
+      table.insert(result, item)
+    end
+  end
+  return result
+end
+
+return Set

--- a/lua/bufferline/sorters.lua
+++ b/lua/bufferline/sorters.lua
@@ -94,11 +94,12 @@ end
 --- @param elements TabElement[]
 function M.sort(elements)
   local sort_by = config.options.sort_by
-  local is_tabline = config:is_tabline()
-
+  -- DO NOTHING
   if sort_by == "none" then
-    -- DO NOTHING, FIXME: can/should we completely avoid this function call
-  elseif sort_by == "extension" then
+    return
+  end
+
+  if sort_by == "extension" then
     table.sort(elements, sort_by_extension)
   elseif sort_by == "directory" then
     table.sort(elements, sort_by_directory)
@@ -107,6 +108,7 @@ function M.sort(elements)
   elseif sort_by == "id" then
     table.sort(elements, sort_by_id)
   elseif sort_by == "tabs" then
+    local is_tabline = config:is_tabline()
     table.sort(elements, is_tabline and sort_by_id or sort_by_tabs)
   elseif type(sort_by) == "function" then
     table.sort(elements, sort_by)

--- a/lua/bufferline/sorters.lua
+++ b/lua/bufferline/sorters.lua
@@ -96,7 +96,9 @@ function M.sort(elements)
   local sort_by = config.options.sort_by
   local is_tabline = config:is_tabline()
 
-  if sort_by == "extension" then
+  if sort_by == "none" then
+    -- DO NOTHING, FIXME: can/should we completely avoid this function call
+  elseif sort_by == "extension" then
     table.sort(elements, sort_by_extension)
   elseif sort_by == "directory" then
     table.sort(elements, sort_by_directory)

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -5,12 +5,14 @@ local M = {}
 -----------------------------------------------------------------------------//
 ---@class BufferlineState
 ---@field components Component[]
+---@field current_element_index number?
 ---@field visible_components Component[]
 ---@field __components Component[]
 ---@field __visible_components Component[]
 ---@field custom_sort number[]
 local state = {
   is_picking = false,
+  current_element_index = nil,
   custom_sort = nil,
   __components = {},
   __visible_components = {},
@@ -20,7 +22,7 @@ local state = {
 
 ---@param value BufferlineState
 function M.set(value)
-  vim.tbl_extend("force", state, value)
+  state = vim.tbl_extend("force", state, value)
 end
 
 function M.get()


### PR DESCRIPTION
This refactors the *buffer* handling to use an ordered set to maintain internal buffer state, rather than just directly reproducing the list we get from nvim. With more control, we can now add buffers at specific points in the list

Fixes #232 