### PR TITLE
feat: add groups dynamically

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -38,6 +38,7 @@ local M = {
   close_with_pick = commands.close_with_pick,
   close_in_direction = commands.close_in_direction,
   handle_group_click = commands.handle_group_click,
+  add_group = groups.collect_group_data,
   -- @deprecate
   go_to_buffer = commands.go_to,
   sort_buffers_by = commands.sort_by,
@@ -246,6 +247,7 @@ local function setup_commands()
     { name = "BufferLineSortByRelativeDirectory", cmd = 'sort_buffers_by("relative_directory")' },
     { name = "BufferLineSortByTabs", cmd = 'sort_buffers_by("tabs")' },
     { name = "BufferLineGoToBuffer", cmd = "go_to_buffer(<q-args>)", nargs = 1 },
+    { name = "BufferLineAddGroup", cmd = "add_group()", nargs = 0 },
     {
       nargs = 1,
       name = "BufferLineGroupClose",

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -1,3 +1,7 @@
+local lazy = require("bufferline.lazy")
+---@module "bufferline.colors"
+local colors = lazy.require("bufferline.colors")
+
 local M = {}
 
 local fmt = string.format
@@ -80,7 +84,7 @@ local function convert_highlights(highlights)
     for attribute, value in pairs(attributes) do
       if type(value) == "table" then
         if value.highlight and value.attribute then
-          updated[hl][attribute] = require("bufferline.colors").get_hex({
+          updated[hl][attribute] = colors.get_hex({
             name = value.highlight,
             attribute = value.attribute,
           })
@@ -216,7 +220,6 @@ local nightly = vim.fn.has("nvim-0.6") > 0
 ---Derive the colors for the bufferline
 ---@return BufferlineHighlights
 local function derive_colors()
-  local colors = require("bufferline.colors")
   local hex = colors.get_hex
   local shade = colors.shade_color
 

--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -66,6 +66,10 @@ function M.set_id(buffer)
   return ungrouped_id
 end
 
+local function next_group_id()
+  return vim.tbl_count(state.user_groups) + 1
+end
+
 ---@param id number
 ---@return Group
 function M.get_by_id(id)
@@ -473,10 +477,9 @@ function M.collect_group_data()
     },
   }
   collect_data(stages, function(group)
-    enrich_group(vim.tbl_count(state.user_groups) + 1, group)
+    group = enrich_group(next_group_id(), group)
     -- TODO: figure out how to apply highlights
-    -- local config = require("bufferline.config")
-    -- set_group_highlights(group.name, group, config.highlightss)
+    set_group_highlights(group.name, group, require("bufferline.config").get("highlights"))
     state.user_groups[group.id] = group
   end)
 end

--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -172,6 +172,28 @@ function M.setup(config)
   state.user_groups = result.list
 end
 
+--- Add the next section of information collection to the group
+---@param group Group
+---@param index number
+---@param stages string[]
+local function collect_data(group, index, stages)
+  vim.ui.input({ prompt = stages[index] }, function(response)
+    group[stages[index]] = response
+    index = index + 1
+    if stages[index] then
+      vim.pretty_print(group)
+      collect_data(group, index, stages)
+    end
+  end)
+end
+
+function M.collect_group_data()
+  local group = {}
+  local index = 1
+  local stages = { "group_name", "icon", "matcher" }
+  collect_data(group, index, stages)
+end
+
 --- Add the current highlight for a specific buffer
 --- NOTE: this function mutates the current highlights.
 ---@param buffer Buffer


### PR DESCRIPTION
This PR adds the ability to dynamically specify a buffer group on the fly. It's currently quite minimal and doesn't allow specifying every field that you normally can using the config. Also complex matchers aren't possible, and it can only match using a regex (vim based as these are more powerful).

![bufferline-group-add](https://user-images.githubusercontent.com/22454918/160798609-4f3b5673-7442-4e8e-9662-691eef26b8fb.gif)


Will fix #347 