### PR TITLE
fix: missing visibility method on TabPage

### DIFF
--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -124,6 +124,12 @@ function Tabpage:new(tab)
   return tab
 end
 
+function Tabpage:visibility()
+  return self:current() and visibility.SELECTED
+    or self:visible() and visibility.INACTIVE
+    or visibility.NONE
+end
+
 function Tabpage:current()
   return api.nvim_get_current_tabpage() == self.id
 end


### PR DESCRIPTION
fix: missing visibility method on TabPage

Added missing method for TabPages.

See: #353