### PR TITLE
refactor: allow setting default icon state

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ require('bufferline').setup {
     color_icons = true | false, -- whether or not to add the filetype icon highlights
     show_buffer_icons = true | false, -- disable filetype icons for buffers
     show_buffer_close_icons = true | false,
+    show_buffer_default_icon = true | false, -- whether or not an unrecognised filetype should show a default icon
     show_close_icon = true | false,
     show_tab_indicators = true | false,
     persist_buffer_sort = true, -- whether or not custom sorted buffers should persist

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -88,6 +88,7 @@ The available settings are: >
             groups = {} -- see :h bufferline-groups for details
             show_buffer_icons = true | false,
             show_buffer_close_icons = true | false,
+            show_buffer_default_icon = true | false, -- whether or not an unrecognised filetype should show a default icon
             show_close_icon = true | false,
             show_tab_indicators = true | false
             persist_buffer_sort = true, -- whether or not custom sorted buffers should persist

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -47,6 +47,7 @@ local colors = lazy.require("bufferline.colors")
 ---@field public color_icons boolean
 ---@field public show_buffer_icons boolean
 ---@field public show_buffer_close_icons boolean
+---@field public show_buffer_default_icon boolean
 ---@field public show_close_icon boolean
 ---@field public show_tab_indicators boolean
 ---@field public enforce_regular_tabs boolean
@@ -569,6 +570,7 @@ local function get_defaults()
       color_icons = true,
       show_buffer_icons = true,
       show_buffer_close_icons = true,
+      show_buffer_default_icon = true,
       show_close_icon = true,
       show_tab_indicators = true,
       enforce_regular_tabs = false,

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -23,6 +23,8 @@ local colors = lazy.require("bufferline.colors")
 
 ---@alias BufferlineMode "'tabs'" | "'buffers'"
 
+---@alias DiagnosticIndicator fun(count: number, level: number, errors: table<string, any>, ctx: table<string, any>): string
+
 ---@class BufferlineOptions
 ---@field public mode BufferlineMode
 ---@field public view string
@@ -56,7 +58,7 @@ local colors = lazy.require("bufferline.colors")
 ---@field public max_prefix_length number
 ---@field public sort_by string
 ---@field public diagnostics boolean
----@field public diagnostics_indicator function?
+---@field public diagnostics_indicator DiagnosticIndicator
 ---@field public diagnostics_update_in_insert boolean
 ---@field public offsets table[]
 ---@field public groups GroupOpts

--- a/lua/bufferline/constants.lua
+++ b/lua/bufferline/constants.lua
@@ -27,4 +27,6 @@ M.visibility = {
   NONE = 3,
 }
 
+M.FOLDER_ICON = ""
+
 return M

--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -1,9 +1,9 @@
 local lazy = require("bufferline.lazy")
--- @module "bufferline.utils"
+--- @module "bufferline.utils"
 local utils = lazy.require("bufferline.utils")
--- @module "bufferline.config"
+--- @module "bufferline.config"
 local config = lazy.require("bufferline.config")
--- @module "bufferline.constants"
+--- @module "bufferline.constants"
 local constants = lazy.require("bufferline.constants")
 
 local M = {}

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -1,5 +1,8 @@
-local utils = require("bufferline.utils")
-local constants = require("bufferline.constants")
+local lazy = require("bufferline.lazy")
+--- @module "bufferline.utils"
+local utils = lazy.require("bufferline.utils")
+--- @module "bufferline.constants"
+local constants = lazy.require("bufferline.constants")
 
 local M = {}
 
@@ -113,7 +116,7 @@ function Tabpage:new(tab)
   tab.modified = vim.bo[tab.buf].modified
   tab.buftype = vim.bo[tab.buf].buftype
   tab.extension = fn.fnamemodify(tab.path, ":e")
-  tab.icon, tab.icon_highlight = require("bufferline.utils").get_icon({
+  tab.icon, tab.icon_highlight = utils.get_icon({
     directory = fn.isdirectory(tab.path) > 0,
     path = tab.path,
     extension = tab.extension,
@@ -176,7 +179,7 @@ function Buffer:new(buf)
   buf.buftype = vim.bo[buf.id].buftype
   buf.extension = fn.fnamemodify(buf.path, ":e")
   local is_directory = fn.isdirectory(buf.path) > 0
-  buf.icon, buf.icon_highlight = require("bufferline.utils").get_icon({
+  buf.icon, buf.icon_highlight = utils.get_icon({
     directory = is_directory,
     path = buf.path,
     extension = buf.extension,

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -1,6 +1,8 @@
 ---------------------------------------------------------------------------//
 -- HELPERS
 ---------------------------------------------------------------------------//
+local constants = require("bufferline.constants")
+
 local M = { log = {} }
 
 local fmt = string.format
@@ -240,20 +242,22 @@ function M.get_icon(opts)
   local loaded, webdev_icons = pcall(require, "nvim-web-devicons")
   if opts.directory then
     local hl = loaded and "DevIconDefault" or nil
-    return "", hl
+    return constants.FOLDER_ICON, hl
+  end
+  if not loaded then
+    if fn.exists("*WebDevIconsGetFileTypeSymbol") > 0 then
+      return fn.WebDevIconsGetFileTypeSymbol(opts.path), ""
+    end
+    return "", ""
   end
   if type == "terminal" then
     return webdev_icons.get_icon(type)
   end
-  if loaded then
-    return webdev_icons.get_icon(
-      fn.fnamemodify(opts.path, ":t"),
-      opts.extension,
-      { default = true }
-    )
+  local icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension)
+  if not icon then
+    return "", ""
   end
-  local devicons_loaded = fn.exists("*WebDevIconsGetFileTypeSymbol") > 0
-  return devicons_loaded and fn.WebDevIconsGetFileTypeSymbol(opts.path) or ""
+  return icon, hl
 end
 
 ---Add click action to a component

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -256,7 +256,9 @@ function M.get_icon(opts)
     return webdev_icons.get_icon(type)
   end
   local name = fn.fnamemodify(opts.path, ":t")
-  local icon, hl = webdev_icons.get_icon(name, opts.extension)
+  local icon, hl = webdev_icons.get_icon(name, opts.extension, {
+    default = config.options.show_buffer_default_icon,
+  })
   if not icon then
     return "", ""
   end

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -1,7 +1,11 @@
 ---------------------------------------------------------------------------//
 -- HELPERS
 ---------------------------------------------------------------------------//
-local constants = require("bufferline.constants")
+local lazy = require("bufferline.lazy")
+--- @module "bufferline.constants"
+local constants = lazy.require("bufferline.constants")
+--- @module "bufferline.config"
+local config = lazy.require("bufferline.config")
 
 local M = { log = {} }
 
@@ -16,9 +20,7 @@ end
 
 ---@return boolean
 local function check_logging()
-  ---@type BufferlineOptions
-  local config = require("bufferline.config").get("options")
-  return config.debug.logging
+  return config.options.debug.logging
 end
 
 ---@param msg string
@@ -253,7 +255,8 @@ function M.get_icon(opts)
   if type == "terminal" then
     return webdev_icons.get_icon(type)
   end
-  local icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension)
+  local name = fn.fnamemodify(opts.path, ":t")
+  local icon, hl = webdev_icons.get_icon(name, opts.extension)
   if not icon then
     return "", ""
   end

--- a/tests/bufferline_spec.lua
+++ b/tests/bufferline_spec.lua
@@ -7,15 +7,20 @@ describe("Bufferline tests:", function()
   local bufferline
   ---@module "bufferline.state"
   local state
+  ---@module "nvim-web-devicons"
+  local icons
 
   before_each(function()
     package.loaded["bufferline"] = nil
     package.loaded["bufferline.state"] = nil
+    package.loaded["nvim-web-devicons"] = nil
     -- dependent modules need to also be reset as
     -- they keep track of state themselves now
     package.loaded["bufferline.commands"] = nil
     bufferline = require("bufferline")
     state = require("bufferline.state")
+    icons = require("nvim-web-devicons")
+    icons.setup({ default = true })
   end)
 
   after_each(function()
@@ -106,6 +111,32 @@ describe("Bufferline tests:", function()
       assert.is_truthy(tabline)
       local snapshot = utils.format_tabline(tabline)
       assert.is_equal(snapshot, snapshots[3])
+    end)
+
+    it("should not show a default icon if specified", function()
+      bufferline.setup({
+        options = {
+          show_buffer_default_icon = false,
+        },
+      })
+      vim.cmd("edit test.rrj")
+      local tabline = nvim_bufferline()
+      local snapshot = utils.format_tabline(tabline)
+      local icon = icons.get_icon("")
+      assert.is_false(snapshot:match(icon) == nil)
+    end)
+
+    it("should show a default icon if specified", function()
+      bufferline.setup({
+        options = {
+          show_buffer_default_icon = true,
+        },
+      })
+      vim.cmd("edit test.rrj")
+      local tabline = nvim_bufferline()
+      local snapshot = utils.format_tabline(tabline)
+      local icon = icons.get_icon("")
+      assert.is_true(snapshot:match(icon) ~= nil)
     end)
   end)
 


### PR DESCRIPTION
`nvim-web devicons` allows users to specify if they would like to see default icons or not in their setup, i.e. 
```lua
require('nvim-web-devicons').setup {
	default = true | false
}
```
This plugin has historically ignored this and always used a default icon for consistency. I personally detest the inconsistency of some buffers having icons and some not. Anyway, it's a little annoying for the user that they can't override this despite maybe having expressed a preference in nvim devicons so this PR allows them to disable the default icon via this plugin's config.

I think it's a little strange to have another plugin decide if this plugin shows default icons or not and most importantly, if this was set globally via nvim web devicons then it wouldn't be possible to have specific behaviour just for this plugin i.e. you want defaults off everywhere but this plugin or vice versa.

Fixes #206 