### PR TITLE
feat(config): add numbers highlight

### DIFF
--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -346,6 +346,19 @@ local function derive_colors()
       guibg = normal_bg,
       gui = "bold,italic",
     },
+    numbers = {
+      guifg = comment_fg,
+      guibg = background_color,
+    },
+    numbers_selected = {
+      guifg = normal_fg,
+      guibg = normal_bg,
+      gui = "bold,italic",
+    },
+    numbers_visible = {
+      guifg = comment_fg,
+      guibg = visible_bg,
+    },
     diagnostic = {
       guifg = comment_diagnostic_fg,
       guibg = background_color,

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -116,6 +116,7 @@ function M.for_element(element)
     hl.hint = h.hint_selected.hl
     hl.hint_diagnostic = h.hint_diagnostic_selected.hl
     hl.close_button = h.close_button_selected.hl
+    hl.numbers = h.numbers_selected.hl
   elseif element:visible() then
     hl.background = h.buffer_visible.hl
     hl.modified = h.modified_visible.hl
@@ -133,6 +134,7 @@ function M.for_element(element)
     hl.hint = h.hint_visible.hl
     hl.hint_diagnostic = h.hint_diagnostic_visible.hl
     hl.close_button = h.close_button_visible.hl
+    hl.numbers = h.numbers_visible.hl
   else
     hl.background = h.background.hl
     hl.modified = h.modified.hl
@@ -150,6 +152,7 @@ function M.for_element(element)
     hl.hint = h.hint.hl
     hl.hint_diagnostic = h.hint_diagnostic.hl
     hl.close_button = h.close_button.hl
+    hl.numbers = h.numbers.hl
   end
 
   if element.group then

--- a/lua/bufferline/numbers.lua
+++ b/lua/bufferline/numbers.lua
@@ -126,7 +126,7 @@ function M.component(context)
   if number_prefix ~= "" then
     number_component = number_prefix .. constants.padding
   end
-  component = number_component .. component
+  component = context.current_highlights.numbers .. number_component .. component
   length = length + vim.fn.strwidth(number_component)
   return context:update({ component = component, length = length })
 end

--- a/lua/bufferline/numbers.lua
+++ b/lua/bufferline/numbers.lua
@@ -118,6 +118,7 @@ function M.component(context)
   local component = context.component
   local options = config.options
   local length = context.length
+  local hl = context.current_highlights
   if options.numbers == "none" then
     return context
   end
@@ -126,7 +127,7 @@ function M.component(context)
   if number_prefix ~= "" then
     number_component = number_prefix .. constants.padding
   end
-  component = context.current_highlights.numbers .. number_component .. component
+  component = context.current_highlights.numbers .. number_component .. hl.background .. component
   length = length + vim.fn.strwidth(number_component)
   return context:update({ component = component, length = length })
 end

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -12,6 +12,8 @@ local constants = lazy.require("bufferline.constants")
 local highlights = lazy.require("bufferline.highlights")
 --- @module "bufferline.colors"
 local colors = require("bufferline.colors")
+---@module "bufferline.pick"
+local pick = lazy.require("bufferline.pick")
 
 local M = {}
 local visibility = constants.visibility
@@ -335,7 +337,7 @@ local function add_prefix(context)
   local options = config.options
 
   if context.is_picking and element.letter then
-    component, length = require("bufferline.pick").component(context)
+    component, length = pick.component(context)
   elseif options.show_buffer_icons and element.icon then
     local icon_highlight = highlight_icon(element, options.color_icons, config.highlights)
     component = icon_highlight .. hl.background .. component


### PR DESCRIPTION
Adds the ability to highlight the numbers component, by default these are not highlighted.

fixes #280 

Caveat:
You cannot highlight subcomponents directly as that would be a pain to implement and a lot of complexity with insufficient value IMO