### PR TITLE
CI: update github workflow (use main branch)

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,7 +1,7 @@
 name: stylua
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
     paths-ignore:
       - ".github/**"
       - "*.md"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
       - ".github/**"
       - "*.md"
     branches:
-      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
I'm unsure but I would guess the primary branch for bufferline changed very recently- it happened to break my nvim config when I updated today (because of how packer handles branches) and as I was poking around trying to figure out what happened I noticed these two files still referencing master.

(PS: thanks for the great plugin!)