### PR TITLE
fix: correctly re-export and document exec function

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,14 +675,14 @@ A user can also execute arbitrary functions against a buffer using the
 `exec` function. For example
 
 ```lua
-    require('bufferline.commands').exec(
+    require('bufferline').exec(
         4, -- the forth visible buffer from the left
         user_function -- an arbitrary user function which gets passed the buffer
     )
 
     -- e.g.
     function _G.bdel(num)
-        require('bufferline.commands').exec(num, function(buf, visible_buffers)
+        require('bufferline').exec(num, function(buf, visible_buffers)
             vim.cmd('bdelete '..buf.id)
         end
     end

--- a/README.md
+++ b/README.md
@@ -672,17 +672,17 @@ end
 ### Custom functions
 
 A user can also execute arbitrary functions against a buffer using the
-`buf_exec` function. For example
+`exec` function. For example
 
 ```lua
-    require('bufferline').buf_exec(
+    require('bufferline.commands').exec(
         4, -- the forth visible buffer from the left
         user_function -- an arbitrary user function which gets passed the buffer
     )
 
     -- e.g.
     function _G.bdel(num)
-        require('bufferline').buf_exec(num, function(buf, visible_buffers)
+        require('bufferline.commands').exec(num, function(buf, visible_buffers)
             vim.cmd('bdelete '..buf.id)
         end
     end

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -29,6 +29,7 @@ local positions_key = constants.positions_key
 
 local M = {
   move = commands.move,
+  exec = commands.exec,
   go_to = commands.go_to,
   cycle = commands.cycle,
   sort_by = commands.sort_by,


### PR DESCRIPTION
There seems to have been a few changes to the API that did not get documented in the README.  Wasn't too hard to reverse engineer, so when I figured it out I changed the README to reflect what I found.