### PR TITLE
BREAKING: switch to 0.7 api functions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get neovim v0.5.1
+      - name: Get neovim v0.7.0
         uses: actions/cache@v2
         with:
-          path: build/neovim/v0.5.1
-          key: ${{ runner.os }}-appimage-0.5.1
+          path: build/neovim/v0.7.0
+          key: ${{ runner.os }}-appimage-0.7.0
 
       - name: Fetch dependencies
         run: |
@@ -31,9 +31,9 @@ jobs:
 
       - name: Run tests
         run: |
-          test -d build/neovim/v0.5.1 || {
-            mkdir -p build/neovim/v0.5.1
-            curl -Lo build/neovim/v0.5.1/nvim https://github.com/neovim/neovim/releases/download/v0.5.1/nvim.appimage
-            chmod +x build/neovim/v0.5.1/nvim
+          test -d build/neovim/v0.7.0 || {
+            mkdir -p build/neovim/v0.7.0
+            curl -Lo build/neovim/v0.7.0/nvim https://github.com/neovim/neovim/releases/download/v0.7.0/nvim.appimage
+            chmod +x build/neovim/v0.7.0/nvim
           }
-          build/neovim/v0.5.1/nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"
+          build/neovim/v0.7.0/nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This order can be persisted between sessions (enabled by default).
 
 ## Requirements
 
-- Neovim 0.5+
+- Neovim 0.7+
 - A patched font (see [nerd fonts](https://github.com/ryanoasis/nerd-fonts))
 
 ## Installation

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -314,6 +314,9 @@ end
 
 ---@param conf BufferlineConfig
 function M.setup(conf)
+  if vim.fn.has("nvim-0.7") == 0 then
+    utils.notify("bufferline.nvim requires Neovim 0.7 or higher", utils.E)
+  end
   conf = conf or {}
   config.set(conf)
   local preferences = config.apply()

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -23,7 +23,6 @@ local constants = lazy.require("bufferline.constants")
 local highlights = lazy.require("bufferline.highlights")
 
 local api = vim.api
-local fmt = string.format
 
 local positions_key = constants.positions_key
 local BUFFERLINE_GROUP = "BufferlineCmds"
@@ -237,52 +236,76 @@ end
 ---@param cursor_pos number
 ---@return string[]
 ---@diagnostic disable-next-line: unused-local
-function __bufferline.complete_groups(arg_lead, cmd_line, cursor_pos)
+local function complete_groups(arg_lead, cmd_line, cursor_pos)
   return groups.names()
 end
 
 local function setup_commands()
-  local cmds = {
-    { name = "BufferLinePick", cmd = "pick_buffer()" },
-    { name = "BufferLinePickClose", cmd = "close_buffer_with_pick()" },
-    { name = "BufferLineCycleNext", cmd = "cycle(1)" },
-    { name = "BufferLineCyclePrev", cmd = "cycle(-1)" },
-    { name = "BufferLineCloseRight", cmd = 'close_in_direction("right")' },
-    { name = "BufferLineCloseLeft", cmd = 'close_in_direction("left")' },
-    { name = "BufferLineMoveNext", cmd = "move(1)" },
-    { name = "BufferLineMovePrev", cmd = "move(-1)" },
-    { name = "BufferLineSortByExtension", cmd = 'sort_buffers_by("extension")' },
-    { name = "BufferLineSortByDirectory", cmd = 'sort_buffers_by("directory")' },
-    { name = "BufferLineSortByRelativeDirectory", cmd = 'sort_buffers_by("relative_directory")' },
-    { name = "BufferLineSortByTabs", cmd = 'sort_buffers_by("tabs")' },
-    { name = "BufferLineGoToBuffer", cmd = "go_to_buffer(<q-args>)", nargs = 1 },
-    {
-      nargs = 1,
-      name = "BufferLineGroupClose",
-      cmd = 'group_action(<q-args>, "close")',
-      complete = "complete_groups",
-    },
-    {
-      nargs = 1,
-      name = "BufferLineGroupToggle",
-      cmd = 'group_action(<q-args>, "toggle")',
-      complete = "complete_groups",
-    },
-    {
-      nargs = 0,
-      name = "BufferLineTogglePin",
-      cmd = "toggle_pin()",
-    },
-  }
-  for _, cmd in ipairs(cmds) do
-    local nargs = cmd.nargs and fmt("-nargs=%d", cmd.nargs) or ""
-    local complete = cmd.complete
-        and fmt("-complete=customlist,v:lua.__bufferline.%s", cmd.complete)
-      or ""
-    vim.cmd(
-      fmt('command! %s %s %s lua require("bufferline").%s', nargs, complete, cmd.name, cmd.cmd)
-    )
-  end
+  local cmd = api.nvim_create_user_command
+
+  cmd("BufferLinePick", function()
+    M.pick_buffer()
+  end, {})
+
+  cmd("BufferLinePickClose", function()
+    M.close_buffer_with_pick()
+  end, {})
+
+  cmd("BufferLineCycleNext", function()
+    M.cycle(1)
+  end, {})
+
+  cmd("BufferLineCyclePrev", function()
+    M.cycle(-1)
+  end, {})
+
+  cmd("BufferLineCloseRight", function()
+    M.close_in_direction("right")
+  end, {})
+
+  cmd("BufferLineCloseLeft", function()
+    M.close_in_direction("left")
+  end, {})
+
+  cmd("BufferLineMoveNext", function()
+    M.move(1)
+  end, {})
+
+  cmd("BufferLineMovePrev", function()
+    M.move(-1)
+  end, {})
+
+  cmd("BufferLineSortByExtension", function()
+    M.sort_buffers_by("extension")
+  end, {})
+
+  cmd("BufferLineSortByDirectory", function()
+    M.sort_buffers_by("directory")
+  end, {})
+
+  cmd("BufferLineSortByRelativeDirectory", function()
+    M.sort_buffers_by("relative_directory")
+  end, {})
+
+  cmd("BufferLineSortByTabs", function()
+    M.sort_buffers_by("tabs")
+  end, {})
+
+  cmd("BufferLineGoToBuffer", function(opts)
+    M.go_to_buffer(opts.args)
+  end, { nargs = 1 })
+
+  cmd("BufferLineGroupClose", function(opts)
+    M.group_action(opts.args, "close")
+  end, { nargs = 1, complete = complete_groups })
+
+  cmd("BufferLineGroupToggle", function(opts)
+    M.group_action(opts.args, "toggle")
+  end, { nargs = 1, complete = complete_groups })
+
+  cmd("BufferLineTogglePin", function()
+    M.toggle_pin()
+  end, { nargs = 0 })
 end
 
 ---@private

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -44,9 +44,6 @@ local M = {
   sort_buffers_by = commands.sort_by,
   close_buffer_with_pick = commands.close_with_pick,
 }
-
---- Global namespace for callbacks and other use cases such as commandline completion functions
-_G.__bufferline = __bufferline or {}
 -----------------------------------------------------------------------------//
 -- Helpers
 -----------------------------------------------------------------------------//

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -193,19 +193,6 @@ end
 
 M.path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"
 
--- Source: https://teukka.tech/luanvim.html
-function M.augroup(definitions)
-  for group_name, definition in pairs(definitions) do
-    vim.cmd("augroup " .. group_name)
-    vim.cmd("autocmd!")
-    for _, def in pairs(definition) do
-      local command = table.concat(vim.tbl_flatten({ "autocmd", def }), " ")
-      vim.cmd(command)
-    end
-    vim.cmd("augroup END")
-  end
-end
-
 -- The provided api nvim_is_buf_loaded filters out all hidden buffers
 function M.is_valid(buf_num)
   if not buf_num or buf_num < 1 then


### PR DESCRIPTION
With nvim 0.7 now being stable, this plugin is migrating all the pre-0.7 hacks
for autocommands, commands and highlights to the new apis that allow these things to be done natively in lua