### PR TITLE
v2.0.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get neovim v0.5.1
+      - name: Get neovim v0.7.0
         uses: actions/cache@v2
         with:
-          path: build/neovim/v0.5.1
-          key: ${{ runner.os }}-appimage-0.5.1
+          path: build/neovim/v0.7.0
+          key: ${{ runner.os }}-appimage-0.7.0
 
       - name: Fetch dependencies
         run: |
@@ -31,9 +31,9 @@ jobs:
 
       - name: Run tests
         run: |
-          test -d build/neovim/v0.5.1 || {
-            mkdir -p build/neovim/v0.5.1
-            curl -Lo build/neovim/v0.5.1/nvim https://github.com/neovim/neovim/releases/download/v0.5.1/nvim.appimage
-            chmod +x build/neovim/v0.5.1/nvim
+          test -d build/neovim/v0.7.0 || {
+            mkdir -p build/neovim/v0.7.0
+            curl -Lo build/neovim/v0.7.0/nvim https://github.com/neovim/neovim/releases/download/v0.7.0/nvim.appimage
+            chmod +x build/neovim/v0.7.0/nvim
           }
-          build/neovim/v0.5.1/nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"
+          build/neovim/v0.7.0/nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This order can be persisted between sessions (enabled by default).
 
 ## Requirements
 
-- Neovim 0.5+
+- Neovim 0.7+
 - A patched font (see [nerd fonts](https://github.com/ryanoasis/nerd-fonts))
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -118,12 +118,13 @@ This order can be persisted between sessions (enabled by default).
 ## Installation
 
 It is advised that you specify either the latest tag or a specific tag and bump them manually if you'd prefer to inspect changes before updating.
+If you'd like to use an older version of the plugin compatible with nvim-0.6.1 and below please change your tag to `tag = "v1.*"`
 
 **Lua**
 
 ```lua
 -- using packer.nvim
-use {'akinsho/bufferline.nvim', tag = "*", requires = 'kyazdani42/nvim-web-devicons'}
+use {'akinsho/bufferline.nvim', tag = "v2.*", requires = 'kyazdani42/nvim-web-devicons'}
 ```
 
 **Vimscript**
@@ -131,7 +132,7 @@ use {'akinsho/bufferline.nvim', tag = "*", requires = 'kyazdani42/nvim-web-devic
 ```vim
 Plug 'kyazdani42/nvim-web-devicons' " Recommended (for coloured icons)
 " Plug 'ryanoasis/vim-devicons' Icons without colours
-Plug 'akinsho/bufferline.nvim', { 'tag': '*' }
+Plug 'akinsho/bufferline.nvim', { 'tag': 'v2.*' }
 ```
 
 ## What about Tabs?

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -315,7 +315,11 @@ end
 ---@param conf BufferlineConfig
 function M.setup(conf)
   if vim.fn.has("nvim-0.7") == 0 then
-    utils.notify("bufferline.nvim requires Neovim 0.7 or higher", utils.E, { once = true })
+    utils.notify(
+      "bufferline.nvim requires Neovim 0.7 or higher, please use tag 1.* or update your neovim",
+      utils.E,
+      { once = true }
+    )
     return
   end
   conf = conf or {}

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -315,7 +315,8 @@ end
 ---@param conf BufferlineConfig
 function M.setup(conf)
   if vim.fn.has("nvim-0.7") == 0 then
-    utils.notify("bufferline.nvim requires Neovim 0.7 or higher", utils.E)
+    utils.notify("bufferline.nvim requires Neovim 0.7 or higher", utils.E, { once = true })
+    return
   end
   conf = conf or {}
   config.set(conf)

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -23,9 +23,9 @@ local constants = lazy.require("bufferline.constants")
 local highlights = lazy.require("bufferline.highlights")
 
 local api = vim.api
-local fmt = string.format
 
 local positions_key = constants.positions_key
+local BUFFERLINE_GROUP = "BufferlineCmds"
 
 local M = {
   move = commands.move,
@@ -44,13 +44,10 @@ local M = {
   sort_buffers_by = commands.sort_by,
   close_buffer_with_pick = commands.close_with_pick,
 }
-
---- Global namespace for callbacks and other use cases such as commandline completion functions
-_G.__bufferline = __bufferline or {}
 -----------------------------------------------------------------------------//
 -- Helpers
 -----------------------------------------------------------------------------//
-function M.restore_positions()
+local function restore_positions()
   local str = vim.g[positions_key]
   if not str then
     return str
@@ -120,7 +117,7 @@ local function bufferline()
 end
 
 --- If the item count has changed and the next tabline status is different then update it
-function M.toggle_bufferline()
+local function toggle_bufferline()
   local item_count = config:is_tabline() and utils.get_tab_count() or utils.get_buf_count()
   local status = (config.options.always_show_bufferline or item_count > 1) and 2 or 0
   if vim.o.showtabline ~= status then
@@ -128,50 +125,9 @@ function M.toggle_bufferline()
   end
 end
 
----@private
-function M.__apply_colors()
+local function apply_colors()
   local current_prefs = config.update_highlights()
   highlights.set_all(current_prefs.highlights)
-end
-
----@param conf BufferlineConfig
-local function setup_autocommands(conf)
-  local options = conf.options
-  local autocommands = {
-    { "ColorScheme", "*", [[lua require('bufferline').__apply_colors()]] },
-  }
-  if not options or vim.tbl_isempty(options) then
-    return
-  end
-  if options.persist_buffer_sort then
-    table.insert(autocommands, {
-      "SessionLoadPost",
-      "*",
-      [[lua require'bufferline'.restore_positions()]],
-    })
-  end
-  if not options.always_show_bufferline then
-    -- toggle tabline
-    table.insert(autocommands, {
-      "BufAdd,TabEnter",
-      "*",
-      "lua require'bufferline'.toggle_bufferline()",
-    })
-  end
-
-  table.insert(autocommands, {
-    "BufRead",
-    "*",
-    "++once",
-    "lua vim.schedule(require'bufferline'.handle_group_enter)",
-  })
-  table.insert(autocommands, {
-    "BufEnter",
-    "*",
-    "lua require'bufferline'.handle_group_enter()",
-  })
-
-  utils.augroup({ BufferlineColors = autocommands })
 end
 
 ---@alias group_actions '"close"' | '"toggle"'
@@ -202,7 +158,7 @@ function M.toggle_pin()
   ui.refresh()
 end
 
-function M.handle_group_enter()
+local function handle_group_enter()
   local options = config.options
   local _, element = commands.get_current_element_index(state, { include_hidden = true })
   if not element or not element.group then
@@ -222,68 +178,145 @@ function M.handle_group_enter()
   end)
 end
 
+---@param conf BufferlineConfig
+local function setup_autocommands(conf)
+  local options = conf.options
+  api.nvim_create_augroup(BUFFERLINE_GROUP, { clear = true })
+  api.nvim_create_autocmd("ColorScheme", {
+    pattern = "*",
+    group = BUFFERLINE_GROUP,
+    callback = function()
+      apply_colors()
+    end,
+  })
+  if not options or vim.tbl_isempty(options) then
+    return
+  end
+  if options.persist_buffer_sort then
+    api.nvim_create_autocmd("SessionLoadPost", {
+      pattern = "*",
+      group = BUFFERLINE_GROUP,
+      callback = function()
+        restore_positions()
+      end,
+    })
+  end
+  if not options.always_show_bufferline then
+    -- toggle tabline
+    api.nvim_create_autocmd({ "BufAdd", "TabEnter" }, {
+      pattern = "*",
+      group = BUFFERLINE_GROUP,
+      callback = function()
+        toggle_bufferline()
+      end,
+    })
+  end
+
+  api.nvim_create_autocmd("BufRead", {
+    pattern = "*",
+    once = true,
+    callback = function()
+      vim.schedule(handle_group_enter)
+    end,
+  })
+
+  api.nvim_create_autocmd("BufEnter", {
+    pattern = "*",
+    callback = function()
+      handle_group_enter()
+    end,
+  })
+end
+
 ---@param arg_lead string
 ---@param cmd_line string
 ---@param cursor_pos number
 ---@return string[]
 ---@diagnostic disable-next-line: unused-local
-function __bufferline.complete_groups(arg_lead, cmd_line, cursor_pos)
+local function complete_groups(arg_lead, cmd_line, cursor_pos)
   return groups.names()
 end
 
 local function setup_commands()
-  local cmds = {
-    { name = "BufferLinePick", cmd = "pick_buffer()" },
-    { name = "BufferLinePickClose", cmd = "close_buffer_with_pick()" },
-    { name = "BufferLineCycleNext", cmd = "cycle(1)" },
-    { name = "BufferLineCyclePrev", cmd = "cycle(-1)" },
-    { name = "BufferLineCloseRight", cmd = 'close_in_direction("right")' },
-    { name = "BufferLineCloseLeft", cmd = 'close_in_direction("left")' },
-    { name = "BufferLineMoveNext", cmd = "move(1)" },
-    { name = "BufferLineMovePrev", cmd = "move(-1)" },
-    { name = "BufferLineSortByExtension", cmd = 'sort_buffers_by("extension")' },
-    { name = "BufferLineSortByDirectory", cmd = 'sort_buffers_by("directory")' },
-    { name = "BufferLineSortByRelativeDirectory", cmd = 'sort_buffers_by("relative_directory")' },
-    { name = "BufferLineSortByTabs", cmd = 'sort_buffers_by("tabs")' },
-    { name = "BufferLineGoToBuffer", cmd = "go_to_buffer(<q-args>)", nargs = 1 },
-    {
-      nargs = 1,
-      name = "BufferLineGroupClose",
-      cmd = 'group_action(<q-args>, "close")',
-      complete = "complete_groups",
-    },
-    {
-      nargs = 1,
-      name = "BufferLineGroupToggle",
-      cmd = 'group_action(<q-args>, "toggle")',
-      complete = "complete_groups",
-    },
-    {
-      nargs = 0,
-      name = "BufferLineTogglePin",
-      cmd = "toggle_pin()",
-    },
-  }
-  for _, cmd in ipairs(cmds) do
-    local nargs = cmd.nargs and fmt("-nargs=%d", cmd.nargs) or ""
-    local complete = cmd.complete
-        and fmt("-complete=customlist,v:lua.__bufferline.%s", cmd.complete)
-      or ""
-    vim.cmd(
-      fmt('command! %s %s %s lua require("bufferline").%s', nargs, complete, cmd.name, cmd.cmd)
-    )
-  end
+  local cmd = api.nvim_create_user_command
+
+  cmd("BufferLinePick", function()
+    M.pick_buffer()
+  end, {})
+
+  cmd("BufferLinePickClose", function()
+    M.close_buffer_with_pick()
+  end, {})
+
+  cmd("BufferLineCycleNext", function()
+    M.cycle(1)
+  end, {})
+
+  cmd("BufferLineCyclePrev", function()
+    M.cycle(-1)
+  end, {})
+
+  cmd("BufferLineCloseRight", function()
+    M.close_in_direction("right")
+  end, {})
+
+  cmd("BufferLineCloseLeft", function()
+    M.close_in_direction("left")
+  end, {})
+
+  cmd("BufferLineMoveNext", function()
+    M.move(1)
+  end, {})
+
+  cmd("BufferLineMovePrev", function()
+    M.move(-1)
+  end, {})
+
+  cmd("BufferLineSortByExtension", function()
+    M.sort_buffers_by("extension")
+  end, {})
+
+  cmd("BufferLineSortByDirectory", function()
+    M.sort_buffers_by("directory")
+  end, {})
+
+  cmd("BufferLineSortByRelativeDirectory", function()
+    M.sort_buffers_by("relative_directory")
+  end, {})
+
+  cmd("BufferLineSortByTabs", function()
+    M.sort_buffers_by("tabs")
+  end, {})
+
+  cmd("BufferLineGoToBuffer", function(opts)
+    M.go_to_buffer(opts.args)
+  end, { nargs = 1 })
+
+  cmd("BufferLineGroupClose", function(opts)
+    M.group_action(opts.args, "close")
+  end, { nargs = 1, complete = complete_groups })
+
+  cmd("BufferLineGroupToggle", function(opts)
+    M.group_action(opts.args, "toggle")
+  end, { nargs = 1, complete = complete_groups })
+
+  cmd("BufferLineTogglePin", function()
+    M.toggle_pin()
+  end, { nargs = 0 })
 end
 
 ---@private
 function _G.nvim_bufferline()
   -- Always populate state regardless of if tabline status is less than 2 #352
-  M.toggle_bufferline()
+  toggle_bufferline()
   return bufferline()
 end
 
 ---@param conf BufferlineConfig
 function M.setup(conf)
+  if vim.fn.has("nvim-0.7") == 0 then
+    utils.notify("bufferline.nvim requires Neovim 0.7 or higher", utils.E)
+  end
   conf = conf or {}
   config.set(conf)
   local preferences = config.apply()
@@ -292,7 +325,7 @@ function M.setup(conf)
   setup_commands()
   setup_autocommands(preferences)
   vim.o.tabline = "%!v:lua.nvim_bufferline()"
-  M.toggle_bufferline()
+  toggle_bufferline()
 end
 
 return M

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -77,8 +77,8 @@ local colors = lazy.require("bufferline.colors")
 ---@field public options BufferlineOptions
 ---@field public highlights BufferlineHighlights
 ---@field private original BufferlineConfig original copy of user preferences
----@field private merge fun(BufferlineConfig): BufferlineConfig
----@field private validate fun(BufferlineConfig): nil
+---@field private merge fun(self:BufferlineConfig, BufferlineConfig): BufferlineConfig
+---@field private validate fun(self:BufferlineConfig, BufferlineConfig): nil
 ---@field private resolve fun()
 
 --- Convert highlights specified as tables to the correct existing colours

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -77,6 +77,9 @@ local colors = lazy.require("bufferline.colors")
 ---@field public options BufferlineOptions
 ---@field public highlights BufferlineHighlights
 ---@field private original BufferlineConfig original copy of user preferences
+---@field private merge fun(BufferlineConfig): BufferlineConfig
+---@field private validate fun(BufferlineConfig): nil
+---@field private resolve fun()
 
 --- Convert highlights specified as tables to the correct existing colours
 ---@param map BufferlineHighlights

--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -103,16 +103,16 @@ function separator.pill(group, hls, count)
   return { sep_start = { component = indicator, length = length }, sep_end = space_end(hls) }
 end
 
----@param name string,
+---@param group Group,
 ---@param hls  table<string, table<string, string>>
 ---@param count string
 ---@return string, number
 ---@type GroupSeparator
-function separator.tab(name, hls, count)
+function separator.tab(group, hls, count)
   local hl = hls.fill.hl
   local indicator_hl = hls.buffer.hl
-  local length = utils.measure(name, string.rep(padding, 4), count)
-  local indicator = utils.join(hl, padding, indicator_hl, padding, name, count, hl, padding)
+  local length = utils.measure(group.name, string.rep(padding, 4), count)
+  local indicator = utils.join(hl, padding, indicator_hl, padding, group.name, count, hl, padding)
   return { sep_start = { component = indicator, length = length }, sep_end = space_end(hls) }
 end
 

--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -5,6 +5,8 @@ local utils = lazy.require("bufferline.utils")
 local padding = lazy.require("bufferline.constants").padding
 --- @module "bufferline.models"
 local models = lazy.require("bufferline.models")
+--- @module "bufferline.ui"
+local ui = lazy.require("bufferline.ui")
 
 ----------------------------------------------------------------------------------------------------
 -- Types
@@ -47,6 +49,7 @@ local PINNED_ID = "pinned"
 local PINNED_NAME = "pinned"
 local UNGROUPED_NAME = "ungrouped"
 local UNGROUPED_ID = "ungrouped"
+local PINNED_KEY = "BufferlinePinnedBuffers"
 
 local api = vim.api
 local fmt = string.format
@@ -184,6 +187,21 @@ local state = {
   components_by_group = {},
 }
 
+--- Store a list of pinned buffer as a string of ids e.g. "12,10,5"
+--- in a vim.g global variable that can be persisted across vim sessions
+local function persist_pinned_buffers()
+  local pinned = {}
+  for buf, group in pairs(state.manual_groupings) do
+    if group == PINNED_ID then
+      table.insert(pinned, buf)
+    end
+  end
+  if #pinned == 0 then
+    return
+  end
+  vim.g[PINNED_KEY] = table.concat(pinned, ",")
+end
+
 ---@param buffer Buffer
 ---@return number
 local function get_manual_group(buffer)
@@ -192,10 +210,13 @@ end
 
 --- Wrapper to abstract interacting directly with manual groups as the access mechanism
 -- can vary i.e. buffer id or path and this should be changed in a centralised way.
----@param buffer Buffer
+---@param id string
 ---@param group_id number?
-local function set_manual_group(buffer, group_id)
-  state.manual_groupings[buffer.id] = group_id
+local function set_manual_group(id, group_id)
+  state.manual_groupings[id] = group_id
+  if group_id == PINNED_ID then
+    persist_pinned_buffers()
+  end
 end
 
 ---Group buffers based on user criteria
@@ -279,6 +300,20 @@ function M.reset_highlights(highlights)
   end
 end
 
+--- Pull pinned buffers saved in a vim.g global variable and restore them
+--- to the manual_groupings table.
+local function restore_pinned_buffers()
+  local pinned = vim.g[PINNED_KEY]
+  if not pinned then
+    return
+  end
+  local manual_groupings = vim.tbl_map(tonumber, vim.split(pinned, ",")) or {}
+  for _, buf_id in pairs(manual_groupings) do
+    set_manual_group(buf_id, PINNED_ID)
+  end
+  ui.refresh()
+end
+
 --- NOTE: this function mutates the user's configuration.
 --- Add group highlights to the user highlights table
 ---@param config BufferlineConfig
@@ -313,6 +348,9 @@ function M.setup(config)
   for _, group in pairs(state.user_groups) do
     set_group_highlights(group, config.highlights)
   end
+
+  -- Restore pinned buffer from the previous session
+  api.nvim_create_autocmd("SessionLoadPost", { once = true, callback = restore_pinned_buffers })
 end
 
 --- Add the current highlight for a specific buffer
@@ -366,13 +404,14 @@ local group_by_priority = group_by("priority")
 function M.is_pinned(buffer)
   return get_manual_group(buffer) == PINNED_ID
 end
+
 --- Add a buffer to a group manually
 ---@param group_name string
 ---@param buffer Buffer
 function M.add_to_group(group_name, buffer)
   local group = group_by_name(group_name)
   if group then
-    set_manual_group(buffer, group.id)
+    set_manual_group(buffer.id, group.id)
   end
 end
 
@@ -382,7 +421,7 @@ function M.remove_from_group(group_name, buffer)
   local group = group_by_name(group_name)
   if group then
     local id = get_manual_group(buffer)
-    set_manual_group(buffer, id ~= group.id and id or nil)
+    set_manual_group(buffer.id, id ~= group.id and id or nil)
   end
 end
 

--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -112,7 +112,17 @@ function separator.tab(group, hls, count)
   local hl = hls.fill.hl
   local indicator_hl = hls.buffer.hl
   local length = utils.measure(group.name, string.rep(padding, 4), count)
-  local indicator = utils.join(hl, padding, indicator_hl, padding, group.name, count, hl, padding)
+  local indicator = utils.join(
+    hl,
+    padding,
+    indicator_hl,
+    padding,
+    group.name,
+    count,
+    padding,
+    hl,
+    padding
+  )
   return { sep_start = { component = indicator, length = length }, sep_end = space_end(hls) }
 end
 

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -36,7 +36,7 @@ i.e.
 ---@field component function
 ---@field hidden boolean
 ---@field focusable boolean
----@field type "'group_end'" | "'group_start'" | "'buffer'" | "'tabpage'"
+---@field type 'group_end' | 'group_start' | 'buffer' | 'tabpage'
 local Component = {}
 
 ---@param field string
@@ -151,7 +151,6 @@ end
 ---@field public name_formatter function? dictates how the name should be shown
 ---@field public id integer the buffer number
 ---@field public name string the visible name for the file
----@deprecated public filename string the visible name for the file
 ---@field public icon string the icon
 ---@field public icon_highlight string
 ---@field public diagnostics table
@@ -166,6 +165,7 @@ end
 ---@field public group Group
 ---@field public group_fn string
 ---@field public length number the length of the buffer component
+---@deprecated public filename string the visible name for the file
 local Buffer = Component:new({ type = "buffer" })
 
 ---create a new buffer class

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -193,19 +193,6 @@ end
 
 M.path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"
 
--- Source: https://teukka.tech/luanvim.html
-function M.augroup(definitions)
-  for group_name, definition in pairs(definitions) do
-    vim.cmd("augroup " .. group_name)
-    vim.cmd("autocmd!")
-    for _, def in pairs(definition) do
-      local command = table.concat(vim.tbl_flatten({ "autocmd", def }), " ")
-      vim.cmd(command)
-    end
-    vim.cmd("augroup END")
-  end
-end
-
 -- The provided api nvim_is_buf_loaded filters out all hidden buffers
 function M.is_valid(buf_num)
   if not buf_num or buf_num < 1 then


### PR DESCRIPTION
* BREAKING: switch to 0.7 api functions (#378)
	This switches bufferline to use new autocmd, highlight and command APIs,
	all users will be required to update their nvim versions.