### PR TITLE
fix(duplicates): use utils.truncate_name to truncate ancestors

### DIFF
--- a/lua/bufferline/duplicates.lua
+++ b/lua/bufferline/duplicates.lua
@@ -3,6 +3,8 @@ local M = {}
 local lazy = require("bufferline.lazy")
 -- @module "bufferline.config"
 local config = lazy.require("bufferline.config")
+-- @module "bufferline.utils"
+local utils = require("bufferline.utils")
 
 local strwidth = vim.fn.strwidth
 
@@ -67,7 +69,7 @@ local function truncate(dir, depth, max_size)
   -- by dividing the allotted space for each section by the depth i.e.
   -- the amount of ancestors which will be prefixed
   local allowed_size = math.ceil(max_size / depth)
-  return dir:sub(0, allowed_size - strwidth(marker)) .. marker
+  return utils.truncate_name(dir, allowed_size - strwidth(marker) + 1) .. marker
 end
 
 --- @param context RenderContext


### PR DESCRIPTION
To fix this:
![image](https://user-images.githubusercontent.com/36324537/167783575-c4c38f81-860b-4079-8291-fbc591ed4273.png)
