### PR TITLE
refactor: use themable for all highlight settings

### DIFF
--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -18,6 +18,7 @@ local function create_hl(index, side, section, guibg)
     guifg = section.guifg,
     guibg = section.guibg or guibg,
     gui = section.gui,
+    default = true,
   })
   return H.hl(name)
 end

--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -18,7 +18,6 @@ local function create_hl(index, side, section, guibg)
     guifg = section.guifg,
     guibg = section.guibg or guibg,
     gui = section.gui,
-    default = true,
   })
   return H.hl(name)
 end

--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -18,7 +18,6 @@ local function create_hl(index, side, section, guibg)
     guifg = section.guifg,
     guibg = section.guibg or guibg,
     gui = section.gui,
-    default = false,
   })
   return H.hl(name)
 end

--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -18,15 +18,17 @@ local function create_hl(index, side, section, guibg)
     guifg = section.guifg,
     guibg = section.guibg or guibg,
     gui = section.gui,
+    default = true, -- We need to be able to constantly override these highlights so they should always be default
   })
   return H.hl(name)
 end
 
---- nvim_eval_statusline is not available in stable nvim yet
 ---@param text string
 ---@return number
 local function get_size(text)
-  return api.nvim_eval_statusline(text, { use_tabline = true }).width
+  ---@type table<string, number>
+  local data = api.nvim_eval_statusline(text, { use_tabline = true })
+  return data.width
 end
 
 ---Create tabline segment for custom user specified sections

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -79,7 +79,7 @@ local function convert_hl_keys(opts)
   if opts.gui then
     hls = vim.tbl_extend("force", hls, convert_gui(opts.gui))
   end
-  opts.default = vim.F.if_nil(opts.default, config.options.themable)
+  hls.default = vim.F.if_nil(opts.default, config.options.themable)
   return hls
 end
 

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -79,6 +79,7 @@ local function convert_hl_keys(opts)
   if opts.gui then
     hls = vim.tbl_extend("force", hls, convert_gui(opts.gui))
   end
+  opts.default = vim.F.if_nil(opts.default, config.options.themable)
   return hls
 end
 
@@ -116,7 +117,6 @@ function M.set_all(conf)
         fmt("Error setting highlight group: no name for %s - %s", name, vim.inspect(tbl), utils.E)
       )
     else
-      tbl.default = conf.options.themable
       M.set_one(tbl.hl, tbl)
     end
   end


### PR DESCRIPTION
Unless there is a local preference,

this should fix @siduck's issue, but might break @jjc224 @denstiny issues again. Can you all test, please? It's probably most important that @denstiny and @jjc224's issues are fixed since this is the normal/advised usage of this component, so that should work. @siduck's usage is not recommended, so might not be fixable