### PR TITLE
fix(highlights): allow setting GUI attributes to NONE

### DIFF
--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -49,6 +49,9 @@ end
 
 local function convert_gui(guistr)
   local gui = {}
+  if guistr:lower():match("none") then
+    return gui
+  end
   local parts = vim.split(guistr, ",")
   for _, part in ipairs(parts) do
     gui[part] = true

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -64,6 +64,13 @@ local keys = {
   ctermfg = "ctermfg",
   ctermbg = "ctermbg",
   cterm = "cterm",
+  foreground = "foreground",
+  background = "background",
+  italic = "italic",
+  bold = "bold",
+  underline = "underline",
+  undercurl = "undercurl",
+  underdot = "underdot",
 }
 
 --- Transform legacy highlight keys to new nvim_set_hl api keys


### PR DESCRIPTION
This change allows users to directly set the value of `underline`, `undercurl`, `bold`, `italic` etc. rather than relying on `gui` exclusively

fixes #431 