### PR TITLE
fix(highlights): only set cterm values if not termguicolors

### DIFF
--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -64,9 +64,6 @@ local keys = {
   guibg = "background",
   guifg = "foreground",
   default = "default",
-  ctermfg = "ctermfg",
-  ctermbg = "ctermbg",
-  cterm = "cterm",
   foreground = "foreground",
   background = "background",
   italic = "italic",
@@ -75,6 +72,13 @@ local keys = {
   undercurl = "undercurl",
   underdot = "underdot",
 }
+
+---These values will error if a theme does not set a normal ctermfg or ctermbg @see: #433
+if not vim.opt.termguicolors:get() then
+  keys.ctermfg = "ctermfg"
+  keys.ctermbg = "ctermbg"
+  keys.cterm = "cterm"
+end
 
 --- Transform legacy highlight keys to new nvim_set_hl api keys
 ---@param opts table<string, string>

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -260,7 +260,7 @@ local function get_icon_with_highlight(buffer, color_icons, hl_defs)
   local hl_colors = {
     guifg = not color_icons and "fg" or colors.get_color({ name = hl, attribute = "fg" }),
     guibg = colors.get_color({ name = bg_hls[state], attribute = "bg" }),
-    ctermfg = not color_icons and "fg" or colors.get_color({
+    ctermfg = not color_icons and "NONE" or colors.get_color({
       name = hl,
       attribute = "fg",
       cterm = true,

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -260,13 +260,14 @@ local function get_icon_with_highlight(buffer, color_icons, hl_defs)
   local hl_colors = {
     guifg = not color_icons and "fg" or colors.get_color({ name = hl, attribute = "fg" }),
     guibg = colors.get_color({ name = bg_hls[state], attribute = "bg" }),
-    ctermfg = not color_icons and "NONE" or colors.get_color({
-      name = hl,
-      attribute = "fg",
-      cterm = true,
-    }),
-    ctermbg = colors.get_color({ name = bg_hls[state], attribute = "bg", cterm = true }),
   }
+  ---These values will error if a theme does not set a normal ctermfg or ctermbg
+  ---@see: #433
+  if vim.o.termguicolors == 0 then
+    hl_colors.ctermbg = colors.get_color({ name = bg_hls[state], attribute = "bg", cterm = true })
+    hl_colors.ctermfg = not color_icons and "fg"
+      or colors.get_color({ name = hl, attribute = "fg", cterm = true })
+  end
   highlights.set_one(new_hl, hl_colors)
   return { text = icon, highlight = new_hl, attr = { text = "%*" } }
 end

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -260,14 +260,13 @@ local function get_icon_with_highlight(buffer, color_icons, hl_defs)
   local hl_colors = {
     guifg = not color_icons and "fg" or colors.get_color({ name = hl, attribute = "fg" }),
     guibg = colors.get_color({ name = bg_hls[state], attribute = "bg" }),
+    ctermfg = not color_icons and "fg" or colors.get_color({
+      name = hl,
+      attribute = "fg",
+      cterm = true,
+    }),
+    ctermbg = colors.get_color({ name = bg_hls[state], attribute = "bg", cterm = true }),
   }
-  ---These values will error if a theme does not set a normal ctermfg or ctermbg
-  ---@see: #433
-  if vim.o.termguicolors == 0 then
-    hl_colors.ctermbg = colors.get_color({ name = bg_hls[state], attribute = "bg", cterm = true })
-    hl_colors.ctermfg = not color_icons and "fg"
-      or colors.get_color({ name = hl, attribute = "fg", cterm = true })
-  end
   highlights.set_one(new_hl, hl_colors)
   return { text = icon, highlight = new_hl, attr = { text = "%*" } }
 end


### PR DESCRIPTION
Don't use `fg` for cterm colours since this will break if no colour was set for the cterm of a theme or more specifically for the Normal hl group

@rudotriton does this PR fix your issue, will probably break stuff for someone else 🤷🏿 

fixes #433