### PR TITLE
fix(tabs): explicitly convert segments text attribute to string

### DIFF
--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -122,7 +122,7 @@ local function get_component_size(segments)
   local sum = 0
   for _, s in pairs(segments) do
     if has_text(s) then
-      sum = sum + strwidth(s.text)
+      sum = sum + strwidth(tostring(s.text))
     end
   end
   return sum


### PR DESCRIPTION
Explicitly convert the text attribute of each segment to string when calculating the component size. Some values can be numbers.
```
{
  highlight = "BufferLineBackground",
  text = "config.go"
}
{
  text = " "
}
{
  highlight = "BufferLineSeparator",
  text = "▕"
}
{
  highlight = "BufferLineBackground",
  text = " "
}
{
  highlight = "BufferLineBackground",
  text = " "
}
{
  attr = {
    __id = "number"
  },
  highlight = "BufferLineNumbers",
  text = 1
}
``` 