### PR TITLE
version 2.2.1

### DIFF
--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -64,9 +64,6 @@ local keys = {
   guibg = "background",
   guifg = "foreground",
   default = "default",
-  ctermfg = "ctermfg",
-  ctermbg = "ctermbg",
-  cterm = "cterm",
   foreground = "foreground",
   background = "background",
   italic = "italic",
@@ -75,6 +72,13 @@ local keys = {
   undercurl = "undercurl",
   underdot = "underdot",
 }
+
+---These values will error if a theme does not set a normal ctermfg or ctermbg @see: #433
+if not vim.opt.termguicolors:get() then
+  keys.ctermfg = "ctermfg"
+  keys.ctermbg = "ctermbg"
+  keys.cterm = "cterm"
+end
 
 --- Transform legacy highlight keys to new nvim_set_hl api keys
 ---@param opts table<string, string>

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -641,7 +641,7 @@ local function truncate(before, current, after, available_width, marker, visible
     -- available space that means the window is really narrow
     -- so don't show anything
   elseif available_width < current.length then
-    return "", marker, visible
+    return {}, marker, visible
   else
     if before.length >= after.length then
       before:drop(1)

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -122,7 +122,7 @@ local function get_component_size(segments)
   local sum = 0
   for _, s in pairs(segments) do
     if has_text(s) then
-      sum = sum + strwidth(s.text)
+      sum = sum + strwidth(tostring(s.text))
     end
   end
   return sum


### PR DESCRIPTION
* Fixes incorrect truncation behaviour
* Gate setting cterm values if a user is not using termguicolors
* Fix text for each component not being converted to a string before being counted