### PR TITLE
refactor(ui): allow trunctation to follow direction

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -221,7 +221,23 @@ local function setup_autocommands(conf)
 
   api.nvim_create_autocmd("BufEnter", {
     pattern = "*",
-    callback = function()
+    callback = function(args)
+      for index, component in ipairs(state.components) do
+        if component.id == args.buf then
+          state.set({ current_element_pos = index })
+        end
+      end
+      handle_group_enter()
+    end,
+  })
+  api.nvim_create_autocmd("BufLeave", {
+    pattern = "*",
+    callback = function(args)
+      for index, component in ipairs(state.components) do
+        if component.id == args.buf then
+          state.set({ last_element_pos = index })
+        end
+      end
       handle_group_enter()
     end,
   })

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -25,11 +25,14 @@ local colors = lazy.require("bufferline.colors")
 
 ---@alias DiagnosticIndicator fun(count: number, level: number, errors: table<string, any>, ctx: table<string, any>): string
 
+---@alias TruncStrategy "centered" | "uncentered"
+
 ---@class BufferlineOptions
 ---@field public mode BufferlineMode
 ---@field public view string
 ---@field public debug DebugOpts
 ---@field public numbers string
+---@field public truncation_style TruncStrategy
 ---@field public buffer_close_icon string
 ---@field public modified_icon string
 ---@field public close_icon string
@@ -571,6 +574,7 @@ local function get_defaults()
       mode = "buffers",
       themable = true, -- whether or not bufferline highlights can be overriden externally
       numbers = "none",
+      truncation_style = "centered",
       buffer_close_icon = "",
       modified_icon = "●",
       close_icon = "",

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -25,7 +25,9 @@ local colors = lazy.require("bufferline.colors")
 
 ---@alias DiagnosticIndicator fun(count: number, level: number, errors: table<string, any>, ctx: table<string, any>): string
 
----@alias TruncStrategy "centered" | "uncentered"
+---@alias TruncStrategyType "centered" | "uncentered"
+---@alias TruncStrategyWithNum (TruncStrategy | number)[]
+---@alias TruncStrategy TruncStrategyType | TruncStrategyWithNum
 
 ---@class BufferlineOptions
 ---@field public mode BufferlineMode

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -296,6 +296,12 @@ function Section:drop(index)
   end
 end
 
+---The number of items in a section
+---@return integer
+function Section:count()
+  return #self.items
+end
+
 ---@param item TabElement
 function Section:add(item)
   table.insert(self.items, item)

--- a/lua/bufferline/state.lua
+++ b/lua/bufferline/state.lua
@@ -6,12 +6,16 @@ local M = {}
 
 ---@class BufferlineState
 ---@field components Component[]
+---@field current_element_pos number
+---@field last_element_pos number
 ---@field current_element_index number?
 ---@field visible_components Component[]
 ---@field __components Component[]
 ---@field custom_sort number[]
 local state = {
   is_picking = false,
+  current_element_pos = 0,
+  last_element_pos = 0,
   current_element_index = nil,
   custom_sort = nil,
   __components = {},

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -643,13 +643,22 @@ local function truncate(before, current, after, available_width, marker, visible
   elseif available_width < current.length then
     return {}, marker, visible
   else
-    if before.length >= after.length then
-      before:drop(1)
-      marker.left_count = marker.left_count + 1
+    -- TODO: by changing the side that overflowing buffers are dropped from
+    -- the position of the current buffer will move within the line rather
+    -- than always being centered
+    local to_drop, not_drop = after, before
+    if to_drop:count() > 0 then
+      to_drop:drop(1)
     else
-      after:drop(#after.items)
-      marker.right_count = marker.right_count + 1
+      not_drop:drop(#not_drop.items)
     end
+    -- if before.length >= after.length then
+    --   before:drop(1)
+    --   marker.left_count = marker.left_count + 1
+    -- else
+    --   after:drop(#after.items)
+    --   marker.right_count = marker.right_count + 1
+    -- end
     -- drop the markers if the window is too narrow
     -- this assumes we have dropped both before and after
     -- sections since if the space available is this small

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -251,23 +251,23 @@ local function get_icon_with_highlight(buffer, color_icons, hl_defs)
     return { text = icon }
   end
 
-  local state = buffer:visibility()
+  local vis_state = buffer:visibility()
   local bg_hls = {
     [visibility.INACTIVE] = hl_defs.buffer_visible.hl,
     [visibility.SELECTED] = hl_defs.buffer_selected.hl,
     [visibility.NONE] = hl_defs.background.hl,
   }
 
-  local new_hl = highlights.generate_name(hl, { visibility = state })
+  local new_hl = highlights.generate_name(hl, { visibility = vis_state })
   local hl_colors = {
     guifg = not color_icons and "fg" or colors.get_color({ name = hl, attribute = "fg" }),
-    guibg = colors.get_color({ name = bg_hls[state], attribute = "bg" }),
+    guibg = colors.get_color({ name = bg_hls[vis_state], attribute = "bg" }),
     ctermfg = not color_icons and "fg" or colors.get_color({
       name = hl,
       attribute = "fg",
       cterm = true,
     }),
-    ctermbg = colors.get_color({ name = bg_hls[state], attribute = "bg", cterm = true }),
+    ctermbg = colors.get_color({ name = bg_hls[vis_state], attribute = "bg", cterm = true }),
   }
   highlights.set_one(new_hl, hl_colors)
   return { text = icon, highlight = new_hl, attr = { text = "%*" } }
@@ -500,15 +500,15 @@ local function get_tab_indicator(tab_indicators, options)
   return items, length
 end
 
---- @param state BufferlineState
+--- @param curr_state BufferlineState
 --- @param element TabElement
 --- @return TabElement
-function M.element(state, element)
+function M.element(curr_state, element)
   local curr_hl = highlights.for_element(element)
   local ctx = Context:new({
     tab = element,
     current_highlights = curr_hl,
-    is_picking = state.is_picking,
+    is_picking = curr_state.is_picking,
   })
 
   local duplicate_prefix = duplicates.component(ctx)

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -642,6 +642,16 @@ function trunc_strategy.uncentered(before, after, marker, direction)
   end
 end
 
+---@class TruncationOpts
+---@field before Section
+---@field current Section
+---@field after Section
+---@field available_width number
+---@field direction number
+---@field trunc_style TruncStrategy
+---@field marker table
+---@field visible Component[]?
+
 --- PREREQUISITE: active buffer always remains in view
 --- 1. Find amount of available space in the window
 --- 2. Find the amount of space the bufferline will take up
@@ -649,18 +659,19 @@ end
 --- section
 --- 4. Re-check the size, if still too long truncate recursively till it fits
 --- 5. Add the number of truncated buffers as an indicator
----@param before Section
----@param current Section
----@param after Section
----@param available_width number
----@param direction number
----@param trunc_style TruncStrategy
----@param marker table
+---@param opts TruncationOpts
 ---@return Segment[][]
 ---@return table
 ---@return Buffer[]
-local function truncate(before, current, after, available_width, direction, trunc_style, marker, visible)
-  visible = visible or {}
+local function truncate(opts)
+  local before = opts.before
+  local current = opts.current
+  local after = opts.after
+  local available_width = opts.available_width
+  local direction = opts.direction
+  local trunc_style = opts.trunc_style
+  local marker = opts.marker
+  local visible = opts.visible or {}
 
   local left_trunc_marker = get_marker_size(marker.left_count, marker.left_element_size)
   local right_trunc_marker = get_marker_size(marker.right_count, marker.right_element_size)
@@ -694,7 +705,7 @@ local function truncate(before, current, after, available_width, direction, trun
       marker.left_count = 0
       marker.right_count = 0
     end
-    return truncate(before, current, after, available_width, direction, trunc_style, marker, visible)
+    return truncate(opts)
   end
 end
 
@@ -739,20 +750,20 @@ function M.tabline(items, tab_indicators)
 
   local before, current, after = get_sections(items)
   local direction = state.current_element_pos - state.last_element_pos
-  local segments, marker, visible_components = truncate(
-    before,
-    current,
-    after,
-    available_width,
-    direction,
-    config.options.truncation_style,
-    {
+  local segments, marker, visible_components = truncate({
+    before = before,
+    current = current,
+    after = after,
+    available_width = available_width,
+    direction = direction,
+    trunc_style = config.options.truncation_style,
+    marker = {
       left_count = 0,
       right_count = 0,
       left_element_size = left_element_size,
       right_element_size = right_element_size,
-    }
-  )
+    },
+  })
 
   local fill = hl.fill.hl
   local left_marker = get_trunc_marker(left_trunc_icon, fill, fill, marker.left_count)

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -613,7 +613,11 @@ end
 local trunc_strategy = {}
 
 ---@type TruncFunc
-trunc_strategy.centered = function(before, after, marker, _)
+---@param before Section
+---@param after Section
+---@param marker table<string, number>
+---@param _ number
+function trunc_strategy.centered(before, after, marker, _)
   if before.length >= after.length then
     before:drop(1)
     marker.left_count = marker.left_count + 1
@@ -623,11 +627,15 @@ trunc_strategy.centered = function(before, after, marker, _)
   end
 end
 ---@type TruncFunc
-trunc_strategy.uncentered = function(before, after, marker, direction)
-  if direction <= 0 then
+---@param before Section
+---@param after Section
+---@param marker table<string, number>
+---@param direction number
+function trunc_strategy.uncentered(before, after, marker, direction)
+  if direction > 0 and after:count() > 0 then
     after:drop(#after.items)
     marker.right_count = marker.right_count + 1
-  elseif direction > 0 then
+  elseif direction < 0 and before:count() > 0 then
     before:drop(1)
     marker.left_count = marker.left_count + 1
   else
@@ -676,7 +684,7 @@ local function truncate(before, current, after, available_width, direction, mark
     -- by changing the side that overflowing buffers are dropped from
     -- the position of the current buffer will move within the line rather
     -- than always being centered
-    local mode = "centered" -- FIXME: uncentered causes an infinite loop
+    local mode = "uncentered" -- FIXME: uncentered causes an infinite loop
     trunc_strategy[mode](before, after, marker, direction)
     -- drop the markers if the window is too narrow
     -- this assumes we have dropped both before and after


### PR DESCRIPTION
This PR allows the current buffer to navigate till the end of the visible buffer line rather than always staying centered.

This PR fixes #413 
