### PR TITLE
Prevent unsaved buffers to be closed without confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ require('bufferline').setup {
   options = {
     mode = "buffers", -- set to "tabs" to only show tabpages instead
     numbers = "none" | "ordinal" | "buffer_id" | "both" | function({ ordinal, id, lower, raise }): string,
-    close_command = "bdelete! %d",       -- can be a string | function, see "Mouse actions"
-    right_mouse_command = "bdelete! %d", -- can be a string | function, see "Mouse actions"
-    left_mouse_command = "buffer %d",    -- can be a string | function, see "Mouse actions"
-    middle_mouse_command = nil,          -- can be a string | function, see "Mouse actions"
+    close_command = "bdelete %d",       -- can be a string | function, see "Mouse actions"
+    right_mouse_command = "bdelete %d", -- can be a string | function, see "Mouse actions"
+    left_mouse_command = "buffer %d",   -- can be a string | function, see "Mouse actions"
+    middle_mouse_command = nil,         -- can be a string | function, see "Mouse actions"
     -- NOTE: this plugin is designed with this icon in mind,
     -- and so changing this is NOT recommended, this is intended
     -- as an escape hatch for people who cannot bear it for whatever reason

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -68,10 +68,10 @@ The available settings are: >
             --- @deprecated, please specify numbers as a function to customize the styling
             number_style = "superscript" | "" | { "none", "subscript" }, -- buffer_id at index 1, ordinal at index 2
             mappings = true | false,
-            close_command = "bdelete! %d",       -- can be a string | function, see "Mouse actions"
-            right_mouse_command = "bdelete! %d", -- can be a string | function, see "Mouse actions"
-            left_mouse_command = "buffer %d",    -- can be a string | function, see "Mouse actions"
-            middle_mouse_command = nil,          -- can be a string | function, see "Mouse actions"
+            close_command = "bdelete %d",       -- can be a string | function, see "Mouse actions"
+            right_mouse_command = "bdelete %d", -- can be a string | function, see "Mouse actions"
+            left_mouse_command = "buffer %d",   -- can be a string | function, see "Mouse actions"
+            middle_mouse_command = nil,         -- can be a string | function, see "Mouse actions"
             buffer_close_icon= "",
             modified_icon = "●",
             close_icon = "",

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -137,7 +137,7 @@ function M.group_action(name, action)
   assert(name, "A name must be passed to execute a group action")
   if action == "close" then
     groups.command(name, function(b)
-      api.nvim_buf_delete(b.id, { force = true })
+      api.nvim_buf_delete(b.id, {})
     end)
   elseif action == "toggle" then
     groups.toggle_hidden(nil, name)

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -55,7 +55,7 @@ local function delete_element(id)
   if config:is_tabline() then
     vim.cmd("tabclose " .. id)
   else
-    api.nvim_buf_delete(id, { force = true })
+    api.nvim_buf_delete(id, {})
   end
 end
 

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -574,9 +574,9 @@ local function get_defaults()
       buffer_close_icon = "",
       modified_icon = "●",
       close_icon = "",
-      close_command = "bdelete! %d",
+      close_command = "bdelete %d",
       left_mouse_command = "buffer %d",
-      right_mouse_command = "bdelete! %d",
+      right_mouse_command = "bdelete %d",
       middle_mouse_command = nil,
       -- U+2590 ▐ Right half block, this character is right aligned so the
       -- background highlight doesn't appear in the middle


### PR DESCRIPTION
Removed default force flag (!) from `bdelete` and 'api.nvim_buf_delete' commands.

I don't know if it is intentional but IMHO force deleting buffers  is not a user friendly default.

I lost quite some work today by using the default configuration
and using the `BufferLineCloseLeft` and `BufferLineCloseRight`
and not expecting it would close unsaved buffers without confirmation.

---

If the intended behavior is `force` deleting buffers please feel free to close this pull request and maybe you could add a warning to the README that it force deletes buffers, thanks!