### PR TITLE
feat(tabpages): add name_formatter

### DIFF
--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -122,7 +122,7 @@ function Tabpage:new(tab)
     extension = tab.extension,
     type = tab.buftype,
   })
-	if tab.name_formatter and type(tab.name_formatter) == "function" then
+  if tab.name_formatter and type(tab.name_formatter) == "function" then
     tab.name = tab.name_formatter({ name = tab.name, path = tab.path, tabnr = tab.id }) or tab.name
   end
   setmetatable(tab, self)

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -122,6 +122,9 @@ function Tabpage:new(tab)
     extension = tab.extension,
     type = tab.buftype,
   })
+	if tab.name_formatter and type(tab.name_formatter) == "function" then
+    tab.name = tab.name_formatter({ name = tab.name, path = tab.path, tabnr = tab.id }) or tab.name
+  end
   setmetatable(tab, self)
   self.__index = self
   return tab


### PR DESCRIPTION
Works :)
![image](https://user-images.githubusercontent.com/56817415/174437401-658490af-47e6-4ea1-b380-fc2c1bcbf2a0.png)

Config used:

```lua
require("bufferline").setup {
	options = {
		mode = "tabs",
		close_command = "tabclose",
		right_mouse_command = "tabclose",
		left_mouse_command = "tabnew %d",
		offsets = {
			{
				filetype = "NvimTree",
				text = "",
				padding = 1,
			},
		},
		name_formatter = function(tab)  -- tab contains a "name", "path" and "tabnr"
			return string.format("name = %s, path = %s, tabnr = %d", tab.name, tab.path, tab.tabnr)
		end,
		buffer_close_icon = "",
		modified_icon = "",
		close_icon = "",
		show_close_icon = false,
		left_trunc_marker = "",
		right_trunc_marker = "",
		max_name_length = 100,
		max_prefix_length = 13,
		tab_size = 20,
		show_tab_indicators = true,
		enforce_regular_tabs = false,
		view = "multiwindow",
		show_buffer_close_icons = true,
		separator_style = "thin",
		always_show_bufferline = true,
		diagnostics = false,
		themable = true,
	},
}
```

Fixes https://github.com/akinsho/bufferline.nvim/issues/454