### PR TITLE
feat: add option/ability to omit diagnostics entirely

### DIFF
--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -178,6 +178,11 @@ function M.component(context)
   local diag_highlight = highlights[diagnostics.level .. "_diagnostic"]
     or highlights.diagnostic
     or ""
+
+  if config.options.diagnostics_pure then
+    indicator = ""
+  end
+
   return {
     text = indicator,
     highlight = diag_highlight,

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -537,7 +537,7 @@ function M.element(state, element)
     set_id(name, components.id.name),
     spacing({ when = name, highlight = curr_hl.buffer.hl }),
     set_id(diagnostic, components.id.diagnostics),
-    spacing({ when = diagnostic }),
+    spacing({ when = diagnostic and not config.options.diagnostics_pure }),
     right_space,
     suffix,
     spacing({ when = suffix }),


### PR DESCRIPTION
![2022-06-20T18:05:36,535511116+04:00](https://user-images.githubusercontent.com/6105977/174620332-bf634192-3a12-4372-a3e5-0ffb4b693f8b.png)
With the new diagnostics_pure=true option two things happen: 
1. The diagnostics count is hidden 
2. The spacing  after diagnostics is hidden.