### PR TITLE
refactor(ui): allow diagnostics to be empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ require('bufferline').setup {
     tab_size = 18,
     diagnostics = false | "nvim_lsp" | "coc",
     diagnostics_update_in_insert = false,
+    -- The diagnostics indicator can be set to nil to keep the buffer name highlight but delete the highlighting
     diagnostics_indicator = function(count, level, diagnostics_dict, context)
       return "("..count..")"
     end,

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -206,6 +206,9 @@ The highlighting for the filename if there is an error can be changed by
 replacing the highlights for `error`, `error_visible`, `error_selected`,
 `warning`, `warning_visible`, `warning_selected`.
 
+The diagnostics indicator can be set to `false` to remove the indicators
+completely whilst still keeping the highlight of the buffer name.
+
 ==============================================================================
 GROUPS                                                      *bufferline-groups*
 

--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -9,6 +9,7 @@ local ui = lazy.require("bufferline.ui")
 local M = {}
 
 local fn = vim.fn
+local fmt = string.format
 
 local severity_name = {
   [1] = "error",
@@ -163,15 +164,12 @@ function M.component(context)
     return
   end
 
-  local indicator = " (" .. diagnostics.count .. ")"
+  local indicator = ""
   if user_indicator and type(user_indicator) == "function" then
     local ctx = { buffer = element, tab = element }
     indicator = user_indicator(diagnostics.count, diagnostics.level, diagnostics.errors, ctx)
-  end
-
-  --- Don't adjust the diagnostic indicator size if it is empty
-  if not indicator or #indicator == 0 then
-    return
+  elseif indicator == nil then
+    indicator = fmt(" (%s)", diagnostics.count)
   end
 
   local highlight = highlights[diagnostics.level] or ""

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -537,7 +537,7 @@ function M.element(state, element)
     set_id(name, components.id.name),
     spacing({ when = name, highlight = curr_hl.buffer.hl }),
     set_id(diagnostic, components.id.diagnostics),
-    spacing({ when = diagnostic }),
+    spacing({ when = diagnostic and #diagnostic.text > 0 }),
     right_space,
     suffix,
     spacing({ when = suffix }),


### PR DESCRIPTION
<img width="311" alt="image" src="https://user-images.githubusercontent.com/22454918/175813963-9f04dd72-ada6-4cd9-bb18-02b65c752394.png">

Supersedes #459 and fixes #452