### PR TITLE
fix(tabpages): use tabpagenr for closing tabpages

### DIFF
--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -92,7 +92,7 @@ end
 function M.handle_close(id)
   local options = config.options
   local close = options.close_command
-  handle_user_command(close, api.nvim_tabpage_get_number(id))
+  handle_user_command(close, id)
 end
 
 ---@param id number

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -92,7 +92,7 @@ end
 function M.handle_close(id)
   local options = config.options
   local close = options.close_command
-  handle_user_command(close, id)
+  handle_user_command(close, api.nvim_tabpage_get_number(id))
 end
 
 ---@param id number

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -632,7 +632,9 @@ function Config:resolve()
     self.options.sort_by = "id"
   end
   if is_tabline then
-    self.options.close_command = "tabclose %d"
+    self.options.close_command = function(tabhandle)
+      vim.cmd('tabclose ' .. vim.api.nvim_tabpage_get_number(tabhandle))
+    end
     self.options.right_mouse_command = "tabclose %d"
     self.options.left_mouse_command = vim.api.nvim_set_current_tabpage
   end


### PR DESCRIPTION
Hey, you might remember me working on tabpage filtering a while ago.

Since then I've discovered a bug where basically bufferline tried to close tabpages using the tabpage handle instead of the tabpagenr.

I finally got the time to find the code responsible for this and fix it! As you can see it was fortunately a very simple fix.