### PR TITLE
feat: go_to_buffer(-1) opens last buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,8 +620,8 @@ Likewise, `BufferLinePickClose` closes the buffer instead of viewing it.
 
 You can select a buffer by it's _visible_ position in the bufferline using the `BufferLineGoToBuffer`
 command. This means that if you have 60 buffers open but only 7 visible in the bufferline
-then using `BufferLineGoToBuffer 4` will go to the 4th visible buffer not necessarily the 5 in the
-absolute list of open buffers.
+using `BufferLineGoToBuffer 4` will go to the 4th visible buffer but not necessarily the 5th in the
+absolute list of open buffers. To select the last visible buffer, you can also use `BufferLineGoToBuffer -1`.
 
 ```
 <- (30) | buf31 | buf32 | buf33 | buf34 | buf35 | buf36 | buf37 (24) ->
@@ -641,6 +641,7 @@ nnoremap <silent><leader>6 <Cmd>BufferLineGoToBuffer 6<CR>
 nnoremap <silent><leader>7 <Cmd>BufferLineGoToBuffer 7<CR>
 nnoremap <silent><leader>8 <Cmd>BufferLineGoToBuffer 8<CR>
 nnoremap <silent><leader>9 <Cmd>BufferLineGoToBuffer 9<CR>
+nnoremap <silent><leader>$ <Cmd>BufferLineGoToBuffer -1<CR>
 ```
 
 Alternatively, if you want to instead jump to the _absolute_ position of the buffer in the bufferline (as displayed by the ordinal buffer numbers), you can use the `lua` API to set it up
@@ -655,7 +656,7 @@ nnoremap <silent><leader>6 <cmd>lua require("bufferline").go_to_buffer(6, true)<
 nnoremap <silent><leader>7 <cmd>lua require("bufferline").go_to_buffer(7, true)<cr>
 nnoremap <silent><leader>8 <cmd>lua require("bufferline").go_to_buffer(8, true)<cr>
 nnoremap <silent><leader>9 <cmd>lua require("bufferline").go_to_buffer(9, true)<cr>
-
+nnoremap <silent><leader>$ <cmd>lua require("bufferline").go_to_buffer(-1, true)<cr>
 ```
 
 ### Mouse actions

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -547,8 +547,8 @@ MAPPINGS                                               *bufferline-mappings*
 
 You can select a buffer by it's visible position in the bufferline using the `BufferLineGoToBuffer`
 command. This means that if you have 60 buffers open but only 7 visible in the bufferline
-then using `BufferLineGoToBuffer 4` will go to the 4th visible buffer not necessarily the 5 in the
-absolute list of open buffers.
+using `BufferLineGoToBuffer 4` will go to the 4th visible buffer but not necessarily the 5th in the
+absolute list of open buffers. To select the last visible buffer, you can also use `BufferLineGoToBuffer -1`.
 >
 
   <- (30) | buf31 | buf32 | buf33 | buf34 | buf35 | buf36 | buf37 (24) ->
@@ -568,6 +568,7 @@ This can then be mapped using
   nnoremap <silent><leader>7 <Cmd>BufferLineGoToBuffer 7<CR>
   nnoremap <silent><leader>8 <Cmd>BufferLineGoToBuffer 8<CR>
   nnoremap <silent><leader>9 <Cmd>BufferLineGoToBuffer 9<CR>
+  nnoremap <silent><leader>$ <Cmd>BufferLineGoToBuffer -1<CR>
 <
 
 If you'd rather map these yourself, use:
@@ -588,6 +589,7 @@ using `require'bufferline'.go_to_buffer(number, absolute)`, where absolute is a 
   nnoremap <silent><leader>7 <cmd>lua require("bufferline").go_to_buffer(7, true)<cr>
   nnoremap <silent><leader>8 <cmd>lua require("bufferline").go_to_buffer(8, true)<cr>
   nnoremap <silent><leader>9 <cmd>lua require("bufferline").go_to_buffer(9, true)<cr>
+  nnoremap <silent><leader>$ <cmd>lua require("bufferline").go_to_buffer(-1, true)<cr>
   
 
 You can close buffers by clicking the close icon or by right clicking the tab anywhere

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -131,6 +131,7 @@ function M.go_to(num, absolute)
   num = type(num) == "string" and tonumber(num) or num
   local list = absolute and state.components or state.visible_components
   local element = list[num]
+  if num == -1 then element = list[#list] end
   if element then open_element(element.id) end
 end
 


### PR DESCRIPTION
Allows to open the buffer in the last visible `go_to_buffer(-1)` or absolute `go_to_buffer(-1, true)`  position.

To keep it light, no further commands were added.
If you like this PR to be extended by adding such commands please feel free to extend it or let me know how I can help. 