### PR TITLE
docs(bufferline.txt): add missing hint highlights

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -701,6 +701,36 @@ highlight command. See `:h highlight` .
                 guibg = '<color-value-here>',
                 gui = "bold,italic"
             },
+            hint = {
+                guifg = '<color-value-here>',
+                guisp = '<color-value-here>',
+                guibg = '<color-value-here>'
+            },
+            hint_visible = {
+                guifg = '<color-value-here>',
+                guibg = '<color-value-here>'
+            },
+            hint_selected = {
+                guifg = '<color-value-here>',
+                guibg = '<color-value-here>',
+                gui = "bold,italic",
+                guisp = '<color-value-here>'
+            },
+            hint_diagnostic = {
+                guifg = '<color-value-here>',
+                guisp = '<color-value-here>',
+                guibg = '<color-value-here>'
+            },
+            hint_diagnostic_visible = {
+                guifg = '<color-value-here>',
+                guibg = '<color-value-here>'
+            },
+            hint_diagnostic_selected = {
+                guifg = '<color-value-here>',
+                guibg = '<color-value-here>',
+                gui = "bold,italic",
+                guisp = '<color-value-here>'
+            },
             info = {
                 guifg = '<color-value-here>',
                 guisp = '<color-value-here>',


### PR DESCRIPTION
Had an occasional highlight that didn't played along and couldn't figure out whats wrong as it was missing in the help docs. 

Let us make the `hint`-group as easy accessible as the other ones 😊