### PR TITLE
feat(tabpages): support unique tab names

### DIFF
--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -93,6 +93,7 @@ function GroupView:current() return false end
 ---@field public letter string
 ---@field public modified boolean
 ---@field public modifiable boolean
+---@field public duplicated boolean
 ---@field public extension string the file extension
 ---@field public path string the full path to the file
 local Tabpage = Component:new({ type = "tab" })
@@ -128,6 +129,23 @@ function Tabpage:current() return api.nvim_get_current_tabpage() == self.id end
 
 --- NOTE: A visible tab page is the current tab page
 function Tabpage:visible() return api.nvim_get_current_tabpage() == self.id end
+
+--- @param depth number
+--- @param formatter function(string, number)
+--- @returns string
+function Tabpage:ancestor(depth, formatter)
+  depth = (depth and depth > 1) and depth or 1
+  local ancestor = ""
+  for index = 1, depth do
+    local modifier = string.rep(":h", index)
+    local dir = fn.fnamemodify(self.path, ":p" .. modifier .. ":t")
+    if dir == "" then break end
+    if formatter then dir = formatter(dir, depth) end
+
+    ancestor = dir .. require("bufferline.utils").path_sep .. ancestor
+  end
+  return ancestor
+end
 
 ---@alias BufferComponent fun(index: number, buf_count: number): string
 

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -8,7 +8,7 @@ local config = lazy.require("bufferline.config")
 ---@module "bufferline.constants"
 local constants = lazy.require("bufferline.constants")
 --- @module "bufferline.duplicates"
-local duplicates = require("bufferline.duplicates")
+local duplicates = lazy.require("bufferline.duplicates")
 ---@module "bufferline.diagnostics"
 local diagnostics = lazy.require("bufferline.diagnostics")
 ---@module "bufferline.utils"

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -7,6 +7,8 @@ local pick = lazy.require("bufferline.pick")
 local config = lazy.require("bufferline.config")
 ---@module "bufferline.constants"
 local constants = lazy.require("bufferline.constants")
+--- @module "bufferline.duplicates"
+local duplicates = require("bufferline.duplicates")
 ---@module "bufferline.diagnostics"
 local diagnostics = lazy.require("bufferline.diagnostics")
 ---@module "bufferline.utils"
@@ -103,6 +105,7 @@ function M.get_components(state)
   ---@type Tabpage[]
   local components = {}
   pick.reset()
+  duplicates.reset()
 
   local filter = options.custom_filter
 
@@ -137,7 +140,7 @@ function M.get_components(state)
     tab.letter = pick.get(tab)
     components[#components + 1] = tab
   end
-  return vim.tbl_map(function(tab) return ui.element(state, tab) end, components)
+  return vim.tbl_map(function(tab) return ui.element(state, tab) end, duplicates.mark(components))
 end
 
 return M


### PR DESCRIPTION
This implements unique names for tabpages.

I looked around for documentation to update, but I don't see anything to change. The feature will just work now for tabs like it does and is described for buffers.

**Here is a screenshot of some unique tabs:**

![image](https://user-images.githubusercontent.com/2261839/180629259-d0fa9b73-23c8-494c-b6f5-df13dee22f83.png)

- _hammerspoon/init.lua_
- _config/nvim/init.lua_
- _config/nvim/lua/wassim/cmp/init.lua_

**For clarity, here is my current config:**

``` lua
require('bufferline').setup({
  options = {
    mode = 'tabs',
    show_buffer_close_icons = true,
    show_close_icon = false,
    always_show_bufferline = false,
    separator_style = 'slant',
    enforce_regular_tabs = false,
    offsets = {
      {
        filetype = 'NvimTree',
        text = nil,
      },
    },
  },
})
```

Closes https://github.com/akinsho/bufferline.nvim/issues/430.