### PR TITLE
feat(commands): fallback to b{prev|next} when cycling buffers

### DIFF
--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -167,6 +167,10 @@ function M.move(direction)
 end
 
 function M.cycle(direction)
+  if vim.opt.showtabline == 0 then
+    if direction > 0 then vim.cmd("bnext") end
+    if direction < 0 then vim.cmd("bprev") end
+  end
   local index = M.get_current_element_index(state)
   if not index then return end
   local length = #state.components


### PR DESCRIPTION
When a user has hidden the tabline this fallback allows cycling with the normal bnext and bprev commands

@Pocco81 can you test this out to see if it works for you.

fixes #488