### PR TITLE
refactor(ui): update offset text overlength handling

### DIFF
--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -30,8 +30,8 @@ local function get_section_text(size, highlight, offset)
   else
     local text_size = fn.strwidth(text)
     local left, right
-    if text_size + 2 >= size then
-      text = text:sub(1, size - 2)
+    if text_size >= size then
+      text = text:sub(1, size - 1) .. "…"
       left, right = 1, 1
     else
       local remainder = size - text_size


### PR DESCRIPTION
This should fix some jumpiness when the offsets text length exceeds the width of the window that the offset is applied for. (Currently, the part of the bufferline that's containing the buffers moves inside the offset if it has overlength). Additionally, the PR adds an indicator that there is more text.

I guess there could be a reason for doing it the way that it is done right now. And I'll probably find out soon. 

But giving you something visual what I'm changing with this PR is probably the easiest, so I'll add two quick and dirty 10sec videos below. For this example, I'm using the path function from the readme that is using a simple `vim.fn.getcwd()` to get the path in the offset.

<details>
<summary>Current:</summary>
https://user-images.githubusercontent.com/34311583/182484665-42084722-dddb-4429-b9f6-cd1eaad8c66f.mp4
</details>

<details>
<summary>PR:</summary>
https://user-images.githubusercontent.com/34311583/182484787-39b06daa-9c1d-4643-9ad9-9bfcbb067da3.mp4
</details>


---

_Little additional obervations with this PR (nothing essential):_
In my usual config, I'm using a custom function to truncate the path in the offset. With this there's one additional thing I'm observing.
The current way of handling overlength sometimes results in some cryptic characters that' are added to the "`sub`bed" text. Sometimes even in crashes when resizing an offset with overlength.
Funnily this seems not to happen anymore when using the changes in the PR. The reasons for this are also yet to be discovered 🧐 (really no idea why the changes in the PR can have an effect on that). Most definitely I could have done better on that truncating function so that the current way of handling this won't result in cryptic chars and stuff.