### PR TITLE
feat(duplicates): handle identical buffers

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -153,12 +153,12 @@ local function handle_group_enter()
   if options.groups.options.toggle_hidden_on_enter then
     if current_group.hidden then groups.set_hidden(current_group.id, false) end
   end
-  utils.for_each(state.components, function(tab)
+  utils.for_each(function(tab)
     local group = groups.get_by_id(tab.group)
     if group and group.auto_close and group.id ~= current_group.id then
       groups.set_hidden(group.id, true)
     end
-  end)
+  end, state.components)
 end
 
 ---@param conf BufferlineConfig

--- a/lua/bufferline/duplicates.lua
+++ b/lua/bufferline/duplicates.lua
@@ -10,41 +10,42 @@ local duplicates = {}
 
 function M.reset() duplicates = {} end
 
+local function is_same_path(a, b, depth)
+  local a_path = vim.split(a, utils.path_sep)
+  local b_path = vim.split(b, utils.path_sep)
+  local a_index = (#a_path - depth) + 1
+  local b_index = (#b_path - depth) + 1
+  return b_path[b_index] == a_path[a_index]
+end
 --- This function marks any duplicate buffers granted
 --- the buffer names have changes
----@param buffers NvimBuffer[]
----@return NvimBuffer[]
-function M.mark(buffers)
-  return vim.tbl_map(function(current)
+---@param elements TabElement[]
+---@return TabElement[]
+function M.mark(elements)
+  return utils.map(function(current)
     -- Do not attempt to mark unnamed files
     if current.path == "" then return current end
     local duplicate = duplicates[current.name]
     if not duplicate then
       duplicates[current.name] = { current }
     else
-      local depth = 1
-      local limit = 10
-      for _, buf in ipairs(duplicate) do
-        local buf_depth = 1
-        while current:ancestor(buf_depth) == buf:ancestor(buf_depth) do
-          -- short circuit if we have gone up 10 directories, we don't expect to have
-          -- to look that far to find a non-matching ancestor and we might be looping
-          -- endlessly
-          if buf_depth >= limit then return end
-
-          buf_depth = buf_depth + 1
+      local depth, limit = 1, 10
+      for _, element in ipairs(duplicate) do
+        local element_depth = 1
+        while is_same_path(current.path, element.path, element_depth) do
+          if element_depth >= limit then break end
+          element_depth = element_depth + 1
         end
-        if buf_depth > depth then depth = buf_depth end
-        buf.duplicated = true
-        buf.prefix_count = buf_depth
-        buffers[buf.ordinal] = buf
+        if element_depth > depth then depth = element_depth end
+        elements[element.ordinal].prefix_count = element_depth
+        elements[element.ordinal].duplicated = true
       end
       current.duplicated = true
       current.prefix_count = depth
       table.insert(duplicate, current)
     end
     return current
-  end, buffers)
+  end, elements)
 end
 
 --- @param dir string

--- a/lua/bufferline/duplicates.lua
+++ b/lua/bufferline/duplicates.lua
@@ -46,7 +46,7 @@ function M.mark(elements)
       end
       current.prefix_count = depth
       current.duplicated = is_repeated and "element" or "path"
-      table.insert(duplicate, current)
+      duplicate[#duplicate + 1] = current
     end
     return current
   end, elements)

--- a/lua/bufferline/duplicates.lua
+++ b/lua/bufferline/duplicates.lua
@@ -58,12 +58,12 @@ local function truncate(dir, depth, max_size)
   -- we truncate any section of the ancestor which is too long
   -- by dividing the allotted space for each section by the depth i.e.
   -- the amount of ancestors which will be prefixed
-  local allowed_size = math.ceil(max_size / depth)
+  local allowed_size = math.floor(max_size / depth) + 1 -- Add one to account for the path separator
   local truncated = utils.map(
-    function(part) return utils.truncate_name(part, allowed_size + 1) end,
+    function(part) return utils.truncate_name(part, allowed_size) end,
     vim.split(dir, utils.path_sep)
   )
-  return table.concat(truncated, utils.path_sep) .. utils.path_sep
+  return table.concat(truncated, utils.path_sep)
 end
 
 --- @param context RenderContext

--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -298,10 +298,10 @@ end
 ---@param callback fun(b: NvimBuffer)
 function M.command(group_name, callback)
   local group = utils.find(
-    state.components_by_group,
-    function(list) return list.name == group_name end
+    function(list) return list.name == group_name end,
+    state.components_by_group
   )
-  utils.for_each(group, callback)
+  utils.for_each(callback, group)
 end
 
 ---@generic T

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -152,7 +152,7 @@ function Tabpage:ancestor(depth, formatter)
     if dir == "" then break end
     if formatter then dir = formatter(dir, depth) end
 
-    ancestor = dir .. require("bufferline.utils").path_sep .. ancestor
+    ancestor = dir .. utils.path_sep .. ancestor
   end
   return ancestor
 end

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -84,7 +84,7 @@ end
 ---@param formatter (fun(path: string, depth: integer): string)?
 ---@return string
 function Component:ancestor(depth, formatter)
-  if not self.type ~= "buffer" or self.type ~= "tab" then return "" end
+  if self.type ~= "buffer" and self.type ~= "tab" then return "" end
   local parts = vim.split(self.path, utils.path_sep, { trimempty = true })
   local index = (depth and depth > #parts) and 1 or (#parts - depth) + 1
   local dir = table.concat(parts, utils.path_sep, index, #parts - 1) .. utils.path_sep

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -245,7 +245,7 @@ function Buffer:current() return api.nvim_get_current_buf() == self.id end
 ---@param state BufferlineState
 ---@return boolean
 function Buffer:is_existing(state)
-  return utils.find(state.components, function(component) return component.id == self.id end) ~= nil
+  return utils.find(function(component) return component.id == self.id end, state.components) ~= nil
 end
 
 -- Find and return the index of the matching buffer (by id) in the list in state

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -102,7 +102,7 @@ function GroupView:current() return false end
 ---@field public letter string
 ---@field public modified boolean
 ---@field public modifiable boolean
----@field public duplicated boolean
+---@field public duplicated "path" | "element" | nil
 ---@field public extension string the file extension
 ---@field public path string the full path to the file
 local Tabpage = Component:new({ type = "tab" })
@@ -144,17 +144,13 @@ function Tabpage:visible() return api.nvim_get_current_tabpage() == self.id end
 --- @param formatter function(string, number)
 --- @returns string
 function Tabpage:ancestor(depth, formatter)
-  depth = (depth and depth > 1) and depth or 1
-  local ancestor = ""
-  for index = 1, depth do
-    local modifier = string.rep(":h", index)
-    local dir = fn.fnamemodify(self.path, ":p" .. modifier .. ":t")
-    if dir == "" then break end
-    if formatter then dir = formatter(dir, depth) end
-
-    ancestor = dir .. utils.path_sep .. ancestor
-  end
-  return ancestor
+  if self.duplicated == "element" then return "(duplicated) " end
+  local parts = vim.split(self.path, utils.path_sep, { trimempty = true })
+  local index = (depth and depth > #parts) and 1 or (#parts - depth) + 1
+  local dir = table.concat(parts, utils.path_sep, index, #parts - 1) .. utils.path_sep
+  if dir == "" then return "" end
+  if formatter then dir = formatter(dir, depth) end
+  return dir
 end
 
 ---@alias BufferComponent fun(index: integer, buf_count: integer): string

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -13,6 +13,8 @@ local duplicates = lazy.require("bufferline.duplicates")
 local diagnostics = lazy.require("bufferline.diagnostics")
 ---@module "bufferline.utils"
 local utils = lazy.require("bufferline.utils")
+---@module "bufferline.models"
+local models = lazy.require("bufferline.models")
 
 local api = vim.api
 
@@ -101,7 +103,7 @@ function M.get_components(state)
   local options = config.options
   local tabs = get_valid_tabs()
 
-  local Tabpage = require("bufferline.models").Tabpage
+  local Tabpage = models.Tabpage
   ---@type NvimTab[]
   local components = {}
   pick.reset()

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -72,7 +72,7 @@ end
 ---@param list T[]
 ---@param callback fun(item: T): boolean
 ---@return T?
-function M.find(list, callback)
+function M.find(callback, list)
   for _, v in ipairs(list) do
     if callback(v) then return v end
   end
@@ -106,7 +106,7 @@ end
 ---@param list T[]
 ---@param callback fun(item: `T`)
 ---@param matcher (fun(item: `T`):boolean)?
-function M.for_each(list, callback, matcher)
+function M.for_each(callback, list, matcher)
   for _, item in ipairs(list) do
     if not matcher or matcher(item) then callback(item) end
   end

--- a/tests/duplicates_spec.lua
+++ b/tests/duplicates_spec.lua
@@ -1,0 +1,123 @@
+local Tabpage = require("bufferline.models").Tabpage
+
+describe("Duplicate Tests - ", function()
+  local duplicates = require("bufferline.duplicates")
+  before_each(function()
+    package.loaded["bufferline.duplicates"] = nil
+    duplicates = require("bufferline.duplicates")
+  end)
+
+  it("should mark duplicate files", function()
+    local result = duplicates.mark({
+      {
+        path = "/test/dir_a/dir_b/file.txt",
+        name = "file.txt",
+        ordinal = 1,
+      },
+      {
+        path = "/test/dir_a/dir_c/file.txt",
+        name = "file.txt",
+        ordinal = 2,
+      },
+      {
+        path = "/test/dir_a/result.txt",
+        name = "result.txt",
+        ordinal = 3,
+      },
+    })
+    assert.is_equal(result[1].duplicated, "path")
+    assert.is_equal(result[2].duplicated, "path")
+    assert.falsy(result[3].duplicated)
+    assert.is_equal(#result, 3)
+  end)
+
+  it("should return the correct prefix count", function()
+    local result = duplicates.mark({
+      {
+        path = "/test/dir_a/dir_b/file.txt",
+        name = "file.txt",
+        ordinal = 1,
+      },
+      {
+        path = "/test/dir_a/dir_c/file.txt",
+        name = "file.txt",
+        ordinal = 2,
+      },
+      {
+        path = "/test/dir_a/result.txt",
+        name = "result.txt",
+        ordinal = 3,
+      },
+    })
+    assert.equal(result[1].prefix_count, 2)
+    assert.equal(result[2].prefix_count, 2)
+    assert.falsy(result[3].prefix_count)
+  end)
+
+  it("should indicate if a buffer is exactly the same as another", function()
+    local result = duplicates.mark({
+      {
+        path = "/test/dir_a/dir_b/file.txt",
+        name = "file.txt",
+        ordinal = 1,
+      },
+      {
+        path = "/test/dir_a/dir_b/file.txt",
+        name = "file.txt",
+        ordinal = 2,
+      },
+      {
+        path = "/test/dir_a/result.txt",
+        name = "result.txt",
+        ordinal = 3,
+      },
+    })
+    assert.equal(result[1].duplicated, "element")
+    assert.equal(result[2].duplicated, "element")
+    assert.falsy(result[3].prefix_count)
+  end)
+
+  it("should return a truncated element", function()
+    local config = require("bufferline.config")
+    config.set({ options = { enforce_regular_tabs = false } })
+    config.apply()
+
+    local component = duplicates.component({
+      current_highlights = { duplicate = "TestHighlight" },
+      tab = Tabpage:new({
+        path = "very_long_directory_name/test/dir_a/result.txt",
+        buf = 1,
+        buffers = { 1 },
+        id = 1,
+        ordinal = 1,
+        diagnostics = {},
+        hidden = false,
+        focusable = true,
+        duplicated = true,
+        prefix_count = 2,
+      }),
+    })
+
+    assert.truthy(component.text)
+    assert.is_equal(component.text, "dir_a/")
+
+    component = duplicates.component({
+      current_highlights = { duplicate = "TestHighlight" },
+      tab = Tabpage:new({
+        path = "very_long_directory_name/test/dir_a/result.txt",
+        buf = 1,
+        buffers = { 1 },
+        id = 1,
+        ordinal = 1,
+        diagnostics = {},
+        hidden = false,
+        focusable = true,
+        duplicated = true,
+        prefix_count = 3,
+      }),
+    })
+
+    assert.truthy(component.text)
+    assert.is_equal(component.text, "test/dir_a/")
+  end)
+end)

--- a/tests/duplicates_spec.lua
+++ b/tests/duplicates_spec.lua
@@ -1,10 +1,13 @@
 local Tabpage = require("bufferline.models").Tabpage
 
 describe("Duplicate Tests - ", function()
-  local duplicates = require("bufferline.duplicates")
+  local duplicates
+  local config
+
   before_each(function()
     package.loaded["bufferline.duplicates"] = nil
     duplicates = require("bufferline.duplicates")
+    config = require("bufferline.config")
   end)
 
   it("should mark duplicate files", function()
@@ -77,7 +80,7 @@ describe("Duplicate Tests - ", function()
     assert.falsy(result[3].prefix_count)
   end)
 
-  it("should return a truncated element", function()
+  it("should return a prefixed element if duplicated", function()
     local config = require("bufferline.config")
     config.set({ options = { enforce_regular_tabs = false } })
     config.apply()
@@ -119,5 +122,29 @@ describe("Duplicate Tests - ", function()
 
     assert.truthy(component.text)
     assert.is_equal(component.text, "test/dir_a/")
+  end)
+
+  it("should truncate a very long directory name", function()
+    config.set({ options = { enforce_regular_tabs = false, max_prefix_length = 10 } })
+    config.apply()
+
+    local component = duplicates.component({
+      current_highlights = { duplicate = "TestHighlight" },
+      tab = Tabpage:new({
+        path = "very_long_directory_name/dir_a/result.txt",
+        buf = 1,
+        buffers = { 1 },
+        id = 1,
+        ordinal = 1,
+        diagnostics = {},
+        hidden = false,
+        focusable = true,
+        duplicated = true,
+        prefix_count = 3,
+      }),
+    })
+
+    assert.is_true(vim.api.nvim_strwidth(component.text) <= 10)
+    assert.is_equal(component.text, "ver…/dir…/")
   end)
 end)


### PR DESCRIPTION
When deduplicating tabpages it is possible for the same buffer to appear twice. Previously that forced the function handling deduplication to exit early, so tabs would not appear in the tabline. This PR changes that function to mark an element as being an exact match to another, which is only relevant for tabs. This way, tabs can have a special indicator to show that a tabs buffer is the same as another.

### TODO
- [x] Add tests for duplicates.lua

fixes #500 