### PR TITLE
fix(offset): truncate long offset text with multibyte characters

### DIFF
--- a/lua/bufferline/constants.lua
+++ b/lua/bufferline/constants.lua
@@ -29,4 +29,6 @@ M.visibility = {
 
 M.FOLDER_ICON = ""
 
+M.ELLIPSIS = "…"
+
 return M

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -31,8 +31,7 @@ local function get_section_text(size, highlight, offset)
   if type(text) == "function" then text = text() end
   text = text or string.rep(" ", size)
 
-  local left, right
-  local text_size = api.nvim_strwidth(text)
+  local text_size, left, right = api.nvim_strwidth(text), 0, 0
   local alignment = offset.text_align or "center"
 
   if text_size + 2 >= size then

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -29,15 +29,14 @@ local function get_section_text(size, highlight, offset)
   local text = offset.text
 
   if type(text) == "function" then text = text() end
-  if not text then text = string.rep(" ", size) end
+  text = text or string.rep(" ", size)
 
   local left, right
   local text_size = api.nvim_strwidth(text)
   local alignment = offset.text_align or "center"
 
   if text_size + 2 >= size then
-    text = utils.truncate_name(text, size - 2)
-    left, right = 1, 1
+    text, left, right = utils.truncate_name(text, size - 2), 1, 1
   else
     local remainder = size - text_size
     local is_even, side = remainder % 2 == 0, remainder / 2
@@ -53,8 +52,7 @@ local function get_section_text(size, highlight, offset)
       left, right = remainder - 1, 1
     end
   end
-  text = string.rep(" ", left) .. text .. string.rep(" ", right)
-  return highlight .. text
+  return highlight .. string.rep(" ", left) .. text .. string.rep(" ", right)
 end
 
 ---A heuristic to attempt to derive a windows background color from a winhighlight

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -1,4 +1,8 @@
+local lazy = require("bufferline.lazy")
+---@module "bufferline.config"
 local config = require("bufferline.config")
+---@module "bufferline.utils"
+local utils = lazy.require("bufferline.utils")
 
 local M = {}
 
@@ -23,33 +27,33 @@ local supported_win_types = {
 ---@return string
 local function get_section_text(size, highlight, offset)
   local text = offset.text
+
   if type(text) == "function" then text = text() end
+  if not text then text = string.rep(" ", size) end
+
+  local left, right
+  local text_size = api.nvim_strwidth(text)
   local alignment = offset.text_align or "center"
-  if not text then
-    text = string.rep(" ", size)
+
+  if text_size + 2 >= size then
+    text = utils.truncate_name(text, size - 2)
+    left, right = 1, 1
   else
-    local text_size = api.nvim_strwidth(text)
-    ---@type integer, integer
-    local left, right
-    if text_size + 2 >= size then
-      text = text:sub(1, size - 2)
-      left, right = 1, 1
-    else
-      local remainder = size - text_size
-      local is_even, side = remainder % 2 == 0, remainder / 2
-      if alignment == "center" then
-        left, right = side, side
-        if not is_even then
-          left, right = math.ceil(side), math.floor(side)
-        end
-      elseif alignment == "left" then
-        left, right = 1, remainder - 1
+    local remainder = size - text_size
+    local is_even, side = remainder % 2 == 0, remainder / 2
+    if alignment == "center" then
+      if not is_even then
+        left, right = math.ceil(side), math.floor(side)
       else
-        left, right = remainder - 1, 1
+        left, right = side, side
       end
+    elseif alignment == "left" then
+      left, right = 1, remainder - 1
+    else
+      left, right = remainder - 1, 1
     end
-    text = string.rep(" ", left) .. text .. string.rep(" ", right)
   end
+  text = string.rep(" ", left) .. text .. string.rep(" ", right)
   return highlight .. text
 end
 

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -213,14 +213,20 @@ local function truncate_by_cell(str, col_limit)
   return short
 end
 
+--- Truncate a name being mindful of multibyte characters and append an ellipsis
+---@param name string
+---@param word_limit number
+---@return string
 function M.truncate_name(name, word_limit)
-  local trunc_symbol = "…"
   if api.nvim_strwidth(name) <= word_limit then return name end
   -- truncate nicely by seeing if we can drop the extension first
   -- to make things fit if not then truncate abruptly
-  local without_prefix = fn.fnamemodify(name, ":t:r")
-  if api.nvim_strwidth(without_prefix) < word_limit then return without_prefix .. trunc_symbol end
-  return truncate_by_cell(name, word_limit - 1) .. trunc_symbol
+  local ext = fn.fnamemodify(name, ":e")
+  if ext ~= "" then
+    local truncated = name:gsub("%." .. ext, "", 1)
+    if api.nvim_strwidth(truncated) < word_limit then return truncated .. constants.ELLIPSIS end
+  end
+  return truncate_by_cell(name, word_limit - 1) .. constants.ELLIPSIS
 end
 
 function M.is_truthy(value)

--- a/tests/offset_spec.lua
+++ b/tests/offset_spec.lua
@@ -2,6 +2,8 @@ local fn = vim.fn
 local api = vim.api
 local fmt = string.format
 
+local constants = require("bufferline.constants")
+
 local filetype = "test"
 
 local function open_test_panel(direction, ft, on_open)
@@ -99,7 +101,7 @@ describe("Offset tests:", function()
 
     assert.equal(20, size)
     assert.equal("", right)
-    assert.is_equal(" Test buffer buffer ", remove_highlight(left))
+    assert.is_equal(fmt(" Test buffer buffe%s ", constants.ELLIPSIS), remove_highlight(left))
   end)
 
   it("should allow left and right offsets", function()

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -1,0 +1,21 @@
+local api = vim.api
+
+local utils = require("bufferline.utils")
+local constants = require("bufferline.constants")
+
+describe("Utils tests", function()
+  it("should correctly truncate a long name", function()
+    local truncated = utils.truncate_name("/user/test/long/file/folder/name/extension", 10)
+    assert.is_true(api.nvim_strwidth(truncated) <= 10)
+  end)
+
+  it("should prefer dropping a filename extension in order to meet word limit", function()
+    local truncated = utils.truncate_name("filename.md", 10)
+    assert.is_equal(truncated, "filename" .. constants.ELLIPSIS)
+  end)
+
+  it("should prefer dropping a SINGLE filename extension in order to meet word limit", function()
+    local truncated = utils.truncate_name("filename.md.md", 13)
+    assert.is_equal(truncated, "filename.md" .. constants.ELLIPSIS)
+  end)
+end)


### PR DESCRIPTION
This PR fixes #495 

@tobealive can you please try this PR out. It uses the utility function I mentioned to truncate the offset text specified, whether it includes multibyte characters. The issue you were having with that function comes down to the fact that the text was being changed to try and remove the extension, but this was initially intended for use with buffer names with extensions, so it ended up changing the text if using a directory, but that should be fixed now

<img width="455" alt="image" src="https://user-images.githubusercontent.com/22454918/184535445-c1c27e10-1602-4fec-867a-161226022905.png">
