### PR TITLE
Document highlight groups for bufferline tab numbers

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -711,6 +711,20 @@ NOTE: you can specify colors the same way you specify colors for `nvim_set_hl`. 
                 bold = true,
                 italic = true,
             },
+            numbers = {
+                fg = '<color-value-here>',
+                bg = '<color-value-here>',
+            },
+            numbers_visible = {
+                fg = '<color-value-here>',
+                bg = '<color-value-here>',
+            },
+            numbers_selected = {
+                fg = '<color-value-here>',
+                bg = '<color-value-here>',
+                bold = true,
+                italic = true,
+            },
             diagnostic = {
                 fg = '<color-value-here>',
                 bg = '<color-value-here>',


### PR DESCRIPTION
I noticed the following highlight groups are not documented: `numbers`, `numbers_visible` and `numbers_selected`. I had to look in the code to realize they exist. I believe it can be useful for other users to have them in the docs.