### PR TITLE
fix(docs): tiny typo

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -10,7 +10,7 @@ CONTENTS                                      *bufferline*
 
 Introduction...........................: |bufferline-introduction|
 Usage..................................: |bufferline-usage|
-Configuration......................... : |bufferline-configuration|
+Configuration..........................: |bufferline-configuration|
 Styling................................: |bufferline-styling|
 Tabpages...............................: |bufferline-tabpages|
 Numbers................................: |bufferline-numbers|


### PR DESCRIPTION
* I found this while looking at the documentation. It's a tiny typo.