### PR TITLE
feat(config)!: add underline indicator style

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -68,12 +68,9 @@ The available configuration are:
             right_mouse_command = "bdelete! %d", -- can be a string | function, see "Mouse actions"
             left_mouse_command = "buffer %d",    -- can be a string | function, see "Mouse actions"
             middle_mouse_command = nil,          -- can be a string | function, see "Mouse actions"
-            -- NOTE: this plugin is designed with this icon in mind,
-            -- and so changing this is NOT recommended, this is intended
-            -- as an escape hatch for people who cannot bear it for whatever reason
             indicator = {
-                icon = '▎',
-                style = 'icon',
+                icon = '▎', -- this should be omitted if indicator style is 'underline'
+                style = 'icon' | 'underline',
             }
             buffer_close_icon = '',
             modified_icon = '●',

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -71,7 +71,10 @@ The available configuration are:
             -- NOTE: this plugin is designed with this icon in mind,
             -- and so changing this is NOT recommended, this is intended
             -- as an escape hatch for people who cannot bear it for whatever reason
-            indicator_icon = '▎',
+            indicator = {
+                icon = '▎',
+                style = 'icon',
+            }
             buffer_close_icon = '',
             modified_icon = '●',
             close_icon = '',

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -377,6 +377,8 @@ local function derive_colors()
     tab_selected = {
       fg = tabline_sel_bg,
       bg = normal_bg,
+      sp = underline_sp,
+      underline = has_underline_indicator,
     },
     tab_close = {
       fg = comment_fg,
@@ -628,6 +630,16 @@ local function derive_colors()
     separator = {
       fg = separator_background_color,
       bg = background_color,
+    },
+    tab_separator = {
+      fg = separator_background_color,
+      bg = normal_bg,
+    },
+    tab_separator_selected = {
+      fg = separator_background_color,
+      bg = normal_bg,
+      sp = underline_sp,
+      underline = has_underline_indicator,
     },
     indicator_selected = {
       fg = tabline_sel_bg,

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -11,6 +11,8 @@ local utils = lazy.require("bufferline.utils")
 local highlights = lazy.require("bufferline.highlights")
 --- @module "bufferline.colors"
 local colors = lazy.require("bufferline.colors")
+--- @module "bufferline.colors"
+local constants = lazy.require("bufferline.constants")
 
 ---@class DebugOpts
 ---@field logging boolean
@@ -148,12 +150,8 @@ function Config:merge(defaults)
 end
 
 local deprecations = {
-  mappings = {
-    message = "please refer to the BufferLineGoToBuffer section of the README",
-    pending = false,
-  },
-  number_style = {
-    message = "please specify 'numbers' as a function instead. See :h bufferline-numbers for details",
+  indicator_icon = {
+    message = "It should be changed to indicator and icon specified as indicator.icon, with indicator.style = 'icon'",
     pending = true,
   },
 }
@@ -633,7 +631,7 @@ local function derive_colors()
     },
     tab_separator = {
       fg = separator_background_color,
-      bg = normal_bg,
+      bg = background_color,
     },
     tab_separator_selected = {
       fg = separator_background_color,
@@ -697,7 +695,7 @@ local function get_defaults()
     -- background highlight doesn't appear in the middle
     -- alternatives:  right aligned => ▕ ▐ ,  left aligned => ▍
     indicator = {
-      icon = "▎",
+      icon = constants.indicator,
       style = "icon",
     },
     left_trunc_marker = "",
@@ -747,6 +745,9 @@ function Config:resolve(defaults)
     accum[hl_name] = highlights.translate_user_highlights(opts)
     return accum
   end, hl_table_to_color(hl))
+
+  local indicator_icon = vim.tbl_get(self, "options", "indicator_icon")
+  if indicator_icon then self.options.indicator = { icon = indicator_icon, style = "icon" } end
 
   if self:is_tabline() then
     local opts = defaults.options

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -22,6 +22,10 @@ local colors = lazy.require("bufferline.colors")
 ---@field options GroupOptions
 ---@field items Group[]
 
+---@class BufferlineIndicator
+---@field style "underline" | "icon"
+---@field icon string?
+
 ---@alias BufferlineMode "'tabs'" | "'buffers'"
 
 ---@alias DiagnosticIndicator fun(count: number, level: number, errors: table<string, any>, ctx: table<string, any>): string
@@ -39,7 +43,7 @@ local colors = lazy.require("bufferline.colors")
 ---@field public left_mouse_command string | function
 ---@field public right_mouse_command string | function
 ---@field public middle_mouse_command (string | function)?
----@field public indicator_icon string
+---@field public indicator BufferlineIndicator
 ---@field public left_trunc_marker string
 ---@field public right_trunc_marker string
 ---@field public separator_style string
@@ -348,6 +352,11 @@ local function derive_colors()
   local warning_diagnostic_fg = shade(warning_fg, diagnostic_shading)
   local error_diagnostic_fg = shade(error_fg, diagnostic_shading)
 
+  local indicator = vim.tbl_get(config, "user", "options", "indicator")
+  local underline_indicator = indicator.style == "underline"
+
+  local underline_sp = underline_indicator and tabline_sel_bg or nil
+
   return {
     fill = {
       fg = comment_fg,
@@ -384,6 +393,8 @@ local function derive_colors()
     close_button_selected = {
       fg = normal_fg,
       bg = normal_bg,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     background = {
       fg = comment_fg,
@@ -402,6 +413,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     numbers = {
       fg = comment_fg,
@@ -412,6 +425,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     numbers_visible = {
       fg = comment_fg,
@@ -430,6 +445,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     hint = {
       fg = comment_fg,
@@ -570,11 +587,15 @@ local function derive_colors()
     modified_selected = {
       fg = string_fg,
       bg = normal_bg,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     duplicate_selected = {
       fg = duplicate_color,
       italic = true,
       bg = normal_bg,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     duplicate_visible = {
       fg = duplicate_color,
@@ -589,6 +610,8 @@ local function derive_colors()
     separator_selected = {
       fg = separator_background_color,
       bg = normal_bg,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     separator_visible = {
       fg = separator_background_color,
@@ -601,6 +624,8 @@ local function derive_colors()
     indicator_selected = {
       fg = tabline_sel_bg,
       bg = normal_bg,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     indicator_visible = {
       fg = visible_bg,
@@ -611,6 +636,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
+      sp = underline_sp,
+      underline = underline_indicator,
     },
     pick_visible = {
       fg = error_fg,
@@ -634,55 +661,59 @@ end
 -- Icons from https://fontawesome.com/cheatsheet
 ---@return BufferlineConfig
 local function get_defaults()
-  return {
-    ---@type BufferlineOptions
-    options = {
-      mode = "buffers",
-      themable = true, -- whether or not bufferline highlights can be overridden externally
-      numbers = "none",
-      buffer_close_icon = "",
-      modified_icon = "●",
-      close_icon = "",
-      close_command = "bdelete! %d",
-      left_mouse_command = "buffer %d",
-      right_mouse_command = "bdelete! %d",
-      middle_mouse_command = nil,
-      -- U+2590 ▐ Right half block, this character is right aligned so the
-      -- background highlight doesn't appear in the middle
-      -- alternatives:  right aligned => ▕ ▐ ,  left aligned => ▍
-      indicator_icon = "▎",
-      left_trunc_marker = "",
-      right_trunc_marker = "",
-      separator_style = "thin",
-      name_formatter = nil,
-      tab_size = 18,
-      max_name_length = 18,
-      color_icons = true,
-      show_buffer_icons = true,
-      show_buffer_close_icons = true,
-      show_buffer_default_icon = true,
-      show_close_icon = true,
-      show_tab_indicators = true,
-      enforce_regular_tabs = false,
-      always_show_bufferline = true,
-      persist_buffer_sort = true,
-      max_prefix_length = 15,
-      sort_by = "id",
-      diagnostics = false,
-      diagnostics_indicator = nil,
-      diagnostics_update_in_insert = true,
-      offsets = {},
-      groups = {
-        items = {},
-        options = {
-          toggle_hidden_on_enter = true,
-        },
-      },
-      debug = {
-        logging = false,
+  ---@type BufferlineOptions
+  local opts = {
+    mode = "buffers",
+    themable = true, -- whether or not bufferline highlights can be overridden externally
+    numbers = "none",
+    buffer_close_icon = "",
+    modified_icon = "●",
+    close_icon = "",
+    close_command = "bdelete! %d",
+    left_mouse_command = "buffer %d",
+    right_mouse_command = "bdelete! %d",
+    middle_mouse_command = nil,
+    -- U+2590 ▐ Right half block, this character is right aligned so the
+    -- background highlight doesn't appear in the middle
+    -- alternatives:  right aligned => ▕ ▐ ,  left aligned => ▍
+    indicator = {
+      icon = "▎",
+      style = "icon",
+    },
+    left_trunc_marker = "",
+    right_trunc_marker = "",
+    separator_style = "thin",
+    name_formatter = nil,
+    tab_size = 18,
+    max_name_length = 18,
+    color_icons = true,
+    show_buffer_icons = true,
+    show_buffer_close_icons = true,
+    show_buffer_default_icon = true,
+    show_close_icon = true,
+    show_tab_indicators = true,
+    enforce_regular_tabs = false,
+    always_show_bufferline = true,
+    persist_buffer_sort = true,
+    max_prefix_length = 15,
+    sort_by = "id",
+    diagnostics = false,
+    diagnostics_indicator = nil,
+    diagnostics_update_in_insert = true,
+    offsets = {},
+    groups = {
+      items = {},
+      options = {
+        toggle_hidden_on_enter = true,
       },
     },
-    highlights = derive_colors(),
+    debug = {
+      logging = false,
+    },
+  }
+  return {
+    options = opts,
+    highlights = derive_colors(opts),
   }
 end
 

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -353,9 +353,9 @@ local function derive_colors()
   local error_diagnostic_fg = shade(error_fg, diagnostic_shading)
 
   local indicator = vim.tbl_get(config, "user", "options", "indicator")
-  local underline_indicator = indicator.style == "underline"
+  local has_underline_indicator = indicator.style == "underline"
 
-  local underline_sp = underline_indicator and tabline_sel_bg or nil
+  local underline_sp = has_underline_indicator and tabline_sel_bg or nil
 
   return {
     fill = {
@@ -394,7 +394,7 @@ local function derive_colors()
       fg = normal_fg,
       bg = normal_bg,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     background = {
       fg = comment_fg,
@@ -414,7 +414,7 @@ local function derive_colors()
       bold = true,
       italic = true,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     numbers = {
       fg = comment_fg,
@@ -426,7 +426,7 @@ local function derive_colors()
       bold = true,
       italic = true,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     numbers_visible = {
       fg = comment_fg,
@@ -446,7 +446,7 @@ local function derive_colors()
       bold = true,
       italic = true,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     hint = {
       fg = comment_fg,
@@ -462,7 +462,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
-      sp = hint_fg,
+      underline = has_underline_indicator,
+      sp = underline_sp or hint_fg,
     },
     hint_diagnostic = {
       fg = comment_diagnostic_fg,
@@ -478,7 +479,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
-      sp = hint_diagnostic_fg,
+      underline = has_underline_indicator,
+      sp = underline_sp or hint_diagnostic_fg,
     },
     info = {
       fg = comment_fg,
@@ -494,7 +496,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
-      sp = info_fg,
+      underline = has_underline_indicator,
+      sp = underline_sp or info_fg,
     },
     info_diagnostic = {
       fg = comment_diagnostic_fg,
@@ -510,7 +513,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
-      sp = info_diagnostic_fg,
+      underline = has_underline_indicator,
+      sp = underline_sp or info_diagnostic_fg,
     },
     warning = {
       fg = comment_fg,
@@ -526,7 +530,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
-      sp = warning_fg,
+      underline = has_underline_indicator,
+      sp = underline_sp or warning_fg,
     },
     warning_diagnostic = {
       fg = comment_diagnostic_fg,
@@ -542,7 +547,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
-      sp = warning_diagnostic_fg,
+      underline = has_underline_indicator,
+      sp = underline_sp or warning_diagnostic_fg,
     },
     error = {
       fg = comment_fg,
@@ -558,7 +564,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
-      sp = error_fg,
+      underline = has_underline_indicator,
+      sp = underline_sp or error_fg,
     },
     error_diagnostic = {
       fg = comment_diagnostic_fg,
@@ -574,7 +581,8 @@ local function derive_colors()
       bg = normal_bg,
       bold = true,
       italic = true,
-      sp = error_diagnostic_fg,
+      underline = has_underline_indicator,
+      sp = underline_sp or error_diagnostic_fg,
     },
     modified = {
       fg = string_fg,
@@ -588,14 +596,14 @@ local function derive_colors()
       fg = string_fg,
       bg = normal_bg,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     duplicate_selected = {
       fg = duplicate_color,
       italic = true,
       bg = normal_bg,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     duplicate_visible = {
       fg = duplicate_color,
@@ -611,7 +619,7 @@ local function derive_colors()
       fg = separator_background_color,
       bg = normal_bg,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     separator_visible = {
       fg = separator_background_color,
@@ -625,7 +633,7 @@ local function derive_colors()
       fg = tabline_sel_bg,
       bg = normal_bg,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     indicator_visible = {
       fg = visible_bg,
@@ -637,7 +645,7 @@ local function derive_colors()
       bold = true,
       italic = true,
       sp = underline_sp,
-      underline = underline_indicator,
+      underline = has_underline_indicator,
     },
     pick_visible = {
       fg = error_fg,
@@ -713,7 +721,7 @@ local function get_defaults()
   }
   return {
     options = opts,
-    highlights = derive_colors(opts),
+    highlights = derive_colors(),
   }
 end
 

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -352,8 +352,8 @@ local function derive_colors()
   local warning_diagnostic_fg = shade(warning_fg, diagnostic_shading)
   local error_diagnostic_fg = shade(error_fg, diagnostic_shading)
 
-  local indicator = vim.tbl_get(config, "user", "options", "indicator")
-  local has_underline_indicator = indicator.style == "underline"
+  local indicator_style = vim.tbl_get(config, "user", "options", "indicator", "style")
+  local has_underline_indicator = indicator_style == "underline"
 
   local underline_sp = has_underline_indicator and tabline_sel_bg or nil
 

--- a/lua/bufferline/constants.lua
+++ b/lua/bufferline/constants.lua
@@ -4,6 +4,8 @@ local M = {}
 ---------------------------------------------------------------------------//
 M.padding = " "
 
+M.indicator = "▎"
+
 M.sep_names = {
   thin = "thin",
   thick = "thick",

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -27,7 +27,7 @@ local function tab_click_component(num) return "%" .. num .. "T" end
 local function render(tabpage, is_active, style, highlights)
   local h = highlights
   local hl = is_active and h.tab_selected.hl_group or h.tab.hl_group
-  local separator_hl = is_active and h.separator_selected.hl_group or h.separator.hl_group
+  local separator_hl = is_active and h.tab_separator_selected.hl_group or h.tab_separator.hl_group
   local separator_component = style == "thick" and "▐" or "▕"
   local name = padding .. padding .. tabpage.tabnr .. padding
   return {

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -28,7 +28,8 @@ local function render(tabpage, is_active, style, highlights)
   local h = highlights
   local hl = is_active and h.tab_selected.hl_group or h.tab.hl_group
   local separator_hl = is_active and h.tab_separator_selected.hl_group or h.tab_separator.hl_group
-  local separator_component = style == "thick" and "▐" or "▕"
+  local chars = constants.sep_chars[style] or constants.sep_chars.thin
+  local separator_component = chars[2]
   local name = padding .. padding .. tabpage.tabnr .. padding
   return {
     { highlight = hl, text = name, attr = { prefix = tab_click_component(tabpage.tabnr) } },

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -297,11 +297,13 @@ local function add_indicator(context)
   local options = config.options
   local style = options.separator_style
   local symbol, highlight = padding, nil
+  if options.indicator.style ~= "icon" then return { text = padding, highlight = highlight } end
+
   if is_slant(style) then return { text = symbol, highlight = highlight } end
 
   local is_current = element:current()
 
-  symbol = is_current and options.indicator_icon or symbol
+  symbol = is_current and options.indicator.icon or symbol
   highlight = is_current and hl.indicator_selected.hl_group
     or element:visible() and hl.indicator_visible.hl_group
     or curr_hl.buffer

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -297,7 +297,6 @@ local function add_indicator(context)
   local options = config.options
   local style = options.separator_style
   local symbol, highlight = padding, nil
-  if options.indicator.style ~= "icon" then return { text = padding, highlight = highlight } end
 
   if is_slant(style) then return { text = symbol, highlight = highlight } end
 
@@ -307,6 +306,8 @@ local function add_indicator(context)
   highlight = is_current and hl.indicator_selected.hl_group
     or element:visible() and hl.indicator_visible.hl_group
     or curr_hl.buffer
+
+  if options.indicator.style ~= "icon" then return { text = padding, highlight = highlight } end
 
   -- since all non-current buffers do not have an indicator they need
   -- to be padded to make up the difference in size

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -703,6 +703,7 @@ M.components = components
 if utils.is_test() then
   M.to_tabline_str = to_tabline_str
   M.set_id = set_id
+  M.add_indicator = add_indicator
 end
 
 return M

--- a/tests/bufferline_spec.lua
+++ b/tests/bufferline_spec.lua
@@ -40,7 +40,7 @@ describe("Bufferline tests:", function()
       local icon = "R"
       bufferline.setup({
         options = {
-          indicator_icon = icon,
+          indicator = { icon = { icon } },
         },
       })
       vim.cmd("edit test.txt")

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -52,5 +52,47 @@ describe("Config tests", function()
       conf = config.update_highlights()
       assert.is_equal(conf.highlights.buffer_selected.fg, "red")
     end)
+
+    it('should not underline anything if options.indicator.style = "icon"', function()
+      config.set({ options = { indicator = { style = "icon" } } })
+      local conf = config.apply()
+      for _, value in pairs(conf.highlights) do
+        assert.is_falsy(value.underline)
+      end
+    end)
+
+    it('should only underline valid fields if options.indicator.style = "underline"', function()
+      config.set({ options = { indicator = { style = "underline" } } })
+      local conf = config.apply()
+      local valid = {
+        "numbers_selected",
+        "buffer_selected",
+        "modified_selected",
+        "indicator_selected",
+        "tab_selected",
+        "close_button_selected",
+        "tab_separator_selected",
+        "duplicate_selected",
+        "separator_selected",
+        "pick_selected",
+        "close_button_selected",
+        "diagnostic_selected",
+        "error_selected",
+        "error_diagnostic_selected",
+        "info_selected",
+        "info_diagnostic_selected",
+        "warning_selected",
+        "warning_diagnostic_selected",
+        "hint_selected",
+        "hint_diagnostic_selected",
+      }
+      for hl, value in pairs(conf.highlights) do
+        if vim.tbl_contains(valid, hl) then
+          assert.is_true(value.underline)
+        else
+          assert.is_falsy(value.underline)
+        end
+      end
+    end)
   end)
 end)

--- a/tests/ui_spec.lua
+++ b/tests/ui_spec.lua
@@ -1,5 +1,9 @@
 describe("UI Tests", function()
   local ui = require("bufferline.ui")
+  local config = require("bufferline.config")
+  local constants = require("bufferline.constants")
+  local MockBuffer = require("tests.utils").MockBuffer
+
   describe("Render tabline", function()
     it("should convert a list of segments to a tabline string", function()
       local components = {
@@ -18,6 +22,21 @@ describe("UI Tests", function()
         "%#BufferlineIndicatorSelected#|%#BufferlineSelected# %#BufferlineSelected#buffer.txt%#BufferlineSelected# %#BufferlineCloseButton#x",
         str
       )
+    end)
+    it("should not render an indicator if the style is underline", function()
+      config.set({ options = { indicator = { style = "underline" } } })
+      config.apply()
+      local result = ui.add_indicator({ tab = MockBuffer:new({}), highlights = {} })
+      assert.is_truthy(result)
+      assert.is_equal(result.text, " ")
+    end)
+
+    it("should render an indicator if the style is icon", function()
+      config.set({ highlights = { indicator_selected = { hl_group = "IndicatorSelected" } } })
+      config.apply()
+      local result = ui.add_indicator({ tab = MockBuffer:new({}), highlights = {} })
+      assert.is_truthy(result)
+      assert.is_equal(result.text, constants.indicator)
     end)
   end)
 end)

--- a/tests/utils.lua
+++ b/tests/utils.lua
@@ -33,6 +33,8 @@ function MockBuffer:new(o)
   return o
 end
 
+function MockBuffer:current() return true end
+
 function MockBuffer:as_element() return self end
 
 ---@param name string


### PR DESCRIPTION
This PR refactors the `indicator_icon` to be a table called `indicator` which allows now specifying a `style` +/- and `icon`. The only alternative style other than an icon is an underline, which now allows the following appearance. Obviously, a user's mileage will vary depending on their terminal emulator of choice and how it draws underlines.

<img width="1220" alt="Screen Shot 2022-08-18 at 16 27 56" src="https://user-images.githubusercontent.com/22454918/185433990-2540a36f-9640-4a7c-9eef-41081ac8cc70.png">

This is using `kitty` with the underline thickness increased to `150%`
