### PR TITLE
feat(offset): add optional offset win separator

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -116,7 +116,14 @@ The available configuration are:
                     return true
                 end
             end,
-            offsets = {{filetype = "NvimTree", text = "File Explorer" | function , text_align = "left" | "center" | "right"}},
+            offsets = {
+                {
+                    filetype = "NvimTree",
+                    text = "File Explorer" | function ,
+                    text_align = "left" | "center" | "right"
+                    separator = true
+                }
+            },
             color_icons = true | false, -- whether or not to add the filetype icon highlights
             show_buffer_icons = true | false, -- disable filetype icons for buffers
             show_buffer_close_icons = true | false,
@@ -481,7 +488,14 @@ containing the details of the window to avoid. *NOTE:* this is only relevant
 for left or right aligned sidebar windows such as `NvimTree`, `NERDTree` or
 `Vista`
 >
-    offsets = {{filetype = "NvimTree", text = "File Explorer", highlight = "Directory"}}
+    offsets = {
+        {
+            filetype = "NvimTree",
+            text = "File Explorer",
+            highlight = "Directory"
+            separator = true -- use a "true" to enable the default, or set your own character
+        }
+    }
 <
 The `filetype` is used to check whether a particular window is a match, the
 `text` is *optional* and will show above the window if specified.
@@ -505,6 +519,12 @@ is shown above the window.
 
 You can also change the alignment of the text in the offset section using
 `text_align` which can be set to `left`, `right` or `center`.
+
+An offset can also have a separator which mimics the appearance of the
+win separator, and the intent is give a vertical split the appearance of
+a consistent separator. The highlight can be changed using the `offset_separator`
+highlight. The value can be set to a `boolean` (uses the default separator if
+true) or to a string which will be the character that will be used.
 
 Lastly you can specify a `padding` option as well which will increase the
 amount the bufferline is offset beyond just the window width, this isn't
@@ -930,7 +950,11 @@ NOTE: you can specify colors the same way you specify colors for
                 bg = '<color-value-here>',
                 bold = true,
                 italic = true,
-            }
+            },
+            offset_separator = {
+                fg = win_separator_fg,
+                bg = separator_background_color,
+            },
         };
     }
 <

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -330,6 +330,15 @@ local function derive_colors()
     },
   })
 
+  local win_separator_fg = hex({
+    name = "WinSeparator",
+    attribute = "fg",
+    fallback = {
+      name = "VertSplit",
+      attribute = "fg",
+    },
+  })
+
   -- If the colorscheme is bright we shouldn't do as much shading
   -- as this makes light color schemes harder to read
   local is_bright_background = colors.color_is_bright(normal_bg)
@@ -668,6 +677,10 @@ local function derive_colors()
       bg = background_color,
       bold = true,
       italic = true,
+    },
+    offset_separator = {
+      fg = win_separator_fg,
+      bg = separator_background_color,
     },
   }
 end

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -57,7 +57,7 @@ local function get_section_text(size, highlight, offset)
     .. string.rep(" ", left)
     .. text
     .. string.rep(" ", right)
-    .. highlights.hl("WinSeparator")
+    .. highlights.hl(config.highlights.offset_separator.hl_group)
     .. "│"
 end
 

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -24,7 +24,7 @@ local supported_win_types = {
 
 ---Format the content of a neighbouring offset's text
 ---@param size integer
----@param highlight string
+---@param highlight table<string, string>
 ---@param offset table
 ---@return string
 local function get_section_text(size, highlight, offset)
@@ -53,12 +53,11 @@ local function get_section_text(size, highlight, offset)
       left, right = remainder - 1, 1
     end
   end
-  return highlight
-    .. string.rep(" ", left)
-    .. text
-    .. string.rep(" ", right)
-    .. highlights.hl(config.highlights.offset_separator.hl_group)
-    .. "│"
+  local str = highlight.text .. string.rep(" ", left) .. text .. string.rep(" ", right)
+  if not offset.separator then return str end
+
+  local sep_icon = type(offset.separator) == "string" and offset.separator or "│"
+  return str .. highlight.sep .. sep_icon
 end
 
 ---A heuristic to attempt to derive a windows background color from a winhighlight
@@ -126,10 +125,11 @@ end
 ---@return string
 ---@return string
 function M.get()
-  local offsets = config.options.offsets
+  local offsets, hls = config.options.offsets, config.highlights
   local left = ""
   local right = ""
   local total_size = 0
+  local sep_hl = highlights.hl(hls.offset_separator.hl_group)
 
   if offsets and #offsets > 0 then
     local layout = fn.winlayout()
@@ -143,8 +143,8 @@ function M.get()
           local hl_name = offset.highlight
             or guess_window_highlight(win_id)
             or config.highlights.fill.hl_group
-
-          local component = get_section_text(width, highlights.hl(hl_name), offset)
+          local hl = highlights.hl(hl_name)
+          local component = get_section_text(width, { text = hl, sep = sep_hl }, offset)
 
           total_size = total_size + width
 

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -53,7 +53,12 @@ local function get_section_text(size, highlight, offset)
       left, right = remainder - 1, 1
     end
   end
-  return highlight .. string.rep(" ", left) .. text .. string.rep(" ", right)
+  return highlight
+    .. string.rep(" ", left)
+    .. text
+    .. string.rep(" ", right)
+    .. highlights.hl("WinSeparator")
+    .. "│"
 end
 
 ---A heuristic to attempt to derive a windows background color from a winhighlight


### PR DESCRIPTION
This PR allows offsets to have a separator which appears similar to the vertical separator vim uses. This can be used to give the appearance of a complete vertical separator when using bufferline with offsets.

<img width="650" alt="image" src="https://user-images.githubusercontent.com/22454918/185499745-a3666a11-c6f4-4729-b86d-61f22d395856.png">
