### PR TITLE
fix(utils): improve path separator detection on windows

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -126,7 +126,7 @@ function M.tbl_reverse_lookup(tbl)
   return ret
 end
 
-M.path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"
+M.path_sep = vim.startswith(vim.loop.os_uname().sysname, "Windows") and "\\" or "/"
 
 -- The provided api nvim_is_buf_loaded filters out all hidden buffers
 function M.is_valid(buf_num)


### PR DESCRIPTION
`vim.loop.os_uname()` output:
```
{
  machine = "x86_64",
  release = "10.0.19044",
  sysname = "Windows_NT",
  version = "Windows 10 Enterprise"
}
```

'Side-effect' of this is that path separator might look like pipe with some fonts (because of italics) now.