### PR TITLE
docs(help): add missing comma to indicator config

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -71,7 +71,7 @@ The available configuration are:
             indicator = {
                 icon = '▎', -- this should be omitted if indicator style is not 'icon'
                 style = 'icon' | 'underline' | 'none',
-            }
+            },
             buffer_close_icon = '',
             modified_icon = '●',
             close_icon = '',


### PR DESCRIPTION
In updating my config for the new indicator icon settings I was getting an error after copy and pasting from the docs. I noticed it was because of a missing comma in the docs.