### PR TITLE
feat: add option to disable name truncation

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -90,6 +90,7 @@ The available configuration are:
             end,
             max_name_length = 18,
             max_prefix_length = 15, -- prefix used when a buffer is de-duplicated
+            truncate_names = true -- whether or not tab names should be truncated
             tab_size = 18,
             diagnostics = false | "nvim_lsp" | "coc",
             diagnostics_update_in_insert = false,

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -51,6 +51,7 @@ local constants = lazy.require("bufferline.constants")
 ---@field public separator_style string
 ---@field public name_formatter (fun(path: string):string)?
 ---@field public tab_size number
+---@field public autosize boolean
 ---@field public max_name_length number
 ---@field public color_icons boolean
 ---@field public show_buffer_icons boolean

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -51,7 +51,7 @@ local constants = lazy.require("bufferline.constants")
 ---@field public separator_style string
 ---@field public name_formatter (fun(path: string):string)?
 ---@field public tab_size number
----@field public autosize boolean
+---@field public truncate_names boolean
 ---@field public max_name_length number
 ---@field public color_icons boolean
 ---@field public show_buffer_icons boolean
@@ -716,6 +716,7 @@ local function get_defaults()
     right_trunc_marker = "",
     separator_style = "thin",
     name_formatter = nil,
+    truncate_names = true,
     tab_size = 18,
     max_name_length = 18,
     color_icons = true,

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -357,9 +357,9 @@ local function get_max_length(context)
   local padding_size = strwidth(padding) * 2
   local max_length = options.max_name_length
 
-  local auto_size = options.autosize and not options.enforce_regular_tabs
+  local should_truncate = not options.truncate_names and not options.enforce_regular_tabs
   local name_size = strwidth(context.tab.name)
-  if auto_size and name_size >= max_length then return name_size end
+  if should_truncate and name_size >= max_length then return name_size end
 
   if not options.enforce_regular_tabs then return max_length end
   -- estimate the maximum allowed size of a filename given that it will be

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -357,9 +357,9 @@ local function get_max_length(context)
   local padding_size = strwidth(padding) * 2
   local max_length = options.max_name_length
 
-  local should_truncate = not options.truncate_names and not options.enforce_regular_tabs
+  local autosize = not options.truncate_names and not options.enforce_regular_tabs
   local name_size = strwidth(context.tab.name)
-  if should_truncate and name_size >= max_length then return name_size end
+  if autosize and name_size >= max_length then return name_size end
 
   if not options.enforce_regular_tabs then return max_length end
   -- estimate the maximum allowed size of a filename given that it will be

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -690,6 +690,7 @@ if utils.is_test() then
   M.to_tabline_str = to_tabline_str
   M.set_id = set_id
   M.add_indicator = add_indicator
+  M.get_name = get_name
 end
 
 return M

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -26,7 +26,7 @@ local custom_area = lazy.require("bufferline.custom_area")
 local offset = lazy.require("bufferline.offset")
 
 local M = {}
-local visibility = constants.visibility
+
 local sep_names = constants.sep_names
 local sep_chars = constants.sep_chars
 -- string.len counts number of bytes and so the unicode icons are counted
@@ -357,6 +357,10 @@ local function get_max_length(context)
   local padding_size = strwidth(padding) * 2
   local max_length = options.max_name_length
 
+  local auto_size = options.autosize and not options.enforce_regular_tabs
+  local name_size = strwidth(context.tab.name)
+  if auto_size and name_size >= max_length then return name_size end
+
   if not options.enforce_regular_tabs then return max_length end
   -- estimate the maximum allowed size of a filename given that it will be
   -- padded and prefixed with a file icon
@@ -366,8 +370,7 @@ end
 ---@param ctx RenderContext
 ---@return Segment
 local function get_name(ctx)
-  local max_length = get_max_length(ctx)
-  local name = utils.truncate_name(ctx.tab.name, max_length)
+  local name = utils.truncate_name(ctx.tab.name, get_max_length(ctx))
   -- escape filenames that contain "%" as this breaks in statusline patterns
   name = name:gsub("%%", "%%%1")
   return { text = name, highlight = ctx.current_highlights.buffer }

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -9,8 +9,8 @@ local config = lazy.require("bufferline.config")
 
 local M = {}
 
-local fn = vim.fn
-local api = vim.api
+local fn, api = vim.fn, vim.api
+local strwidth = api.nvim_strwidth
 
 function M.is_test()
   ---@diagnostic disable-next-line: undefined-global
@@ -218,7 +218,7 @@ end
 ---@param word_limit number
 ---@return string
 function M.truncate_name(name, word_limit)
-  if api.nvim_strwidth(name) <= word_limit then return name end
+  if strwidth(name) <= word_limit then return name end
   -- truncate nicely by seeing if we can drop the extension first
   -- to make things fit if not then truncate abruptly
   local ext = fn.fnamemodify(name, ":e")

--- a/tests/ui_spec.lua
+++ b/tests/ui_spec.lua
@@ -38,5 +38,25 @@ describe("UI Tests", function()
       assert.is_truthy(result)
       assert.is_equal(result.text, constants.indicator)
     end)
+
+    it("should not truncate the tab name if disabled", function()
+      config.set({ options = { truncate_names = false } })
+      config.apply()
+      local segment = ui.get_name({
+        tab = { name = "a_very_very_very_very_long_name_that_i_use.js", icon = "x" },
+        current_highlights = {},
+      })
+      assert.is_equal(segment.text, "a_very_very_very_very_long_name_that_i_use.js")
+    end)
+
+    it("should truncate the tab name if enabled", function()
+      config.set({ options = { truncate_names = true } })
+      config.apply()
+      local segment = ui.get_name({
+        tab = { name = "a_very_very_very_very_long_name_that_i_use.js", icon = "x" },
+        current_highlights = {},
+      })
+      assert.is_equal(segment.text, "a_very_very_very_…")
+    end)
   end)
 end)


### PR DESCRIPTION
This fixes #532 by allowing a user to set `autosize = true` in `config.options`. With this enabled, users can allow filename to extend up to their full name length.

<img width="1607" alt="image" src="https://user-images.githubusercontent.com/22454918/188099547-48f34c5a-09ed-43dc-a2c7-ec1d70e557e2.png">

Can you test this out @ray-x, I might change the option name in future commits since I'm not sure I like `autosize` it's really not very descriptive.

### TODO
- [x] Docs
- [x] Tests
