### PR TITLE
fix: custom area background highlight

### DIFF
--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -55,12 +55,12 @@ function M.get()
       end
       -- if the user doesn't specify a background use the default
       local hls = config.highlights or {}
-      local guibg = hls.fill and hls.fill.guibg or nil
+      local bg = hls.fill and hls.fill.bg or nil
       local ok, section = pcall(section_fn)
       if ok and section and not vim.tbl_isempty(section) then
         for i, item in ipairs(section) do
           if item.text and type(item.text) == "string" then
-            local hl = create_hl(i, side, item, guibg)
+            local hl = create_hl(i, side, item, bg)
             size = size + get_size(item.text)
             if side == "left" then
               left = left .. hl .. item.text

--- a/tests/custom_area_spec.lua
+++ b/tests/custom_area_spec.lua
@@ -12,7 +12,7 @@ describe("Custom areas -", function()
     bufferline.setup({
       options = {
         custom_areas = {
-          left = function() return { { text = "test", guifg = "red", guibg = "black" } } end,
+          left = function() return { { text = "test", fg = "red", bg = "black" } } end,
         },
       },
     })
@@ -26,13 +26,13 @@ describe("Custom areas -", function()
     bufferline.setup({
       highlights = {
         fill = {
-          guifg = "#000000",
+          fg = "#000000",
         },
       },
       options = {
         custom_areas = {
-          left = function() return { { text = "test", guifg = "red", guibg = "black" } } end,
-          right = function() return { { text = "test1", gui = "italic" } } end,
+          left = function() return { { text = "test", fg = "red", bg = "black" } } end,
+          right = function() return { { text = "test1", italic = true } } end,
         },
       },
     })
@@ -50,7 +50,7 @@ describe("Custom areas -", function()
     bufferline.setup({
       options = {
         custom_areas = {
-          left = function() return { { text = { "test" }, guifg = "red", guibg = "black" } } end,
+          left = function() return { { text = { "test" }, fg = "red", bg = "black" } } end,
           right = function() error("This failed mysteriously") end,
         },
       },


### PR DESCRIPTION
Hi there!

This PR fixes a minor bug introduced with https://github.com/akinsho/bufferline.nvim/pull/497 that prevents the default fill background from being used in custom areas.

I've also updated the references in the test, but I couldn't figure out how to run the tests, so I hope it's okay :woman_shrugging:

Thanks for the fantastic plugin!