### PR TITLE
Pass more information to name_formatter

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -83,11 +83,22 @@ The available configuration are:
             --- Please note some names can/will break the
             --- bufferline so use this at your discretion knowing that it has
             --- some limitations that will *NOT* be fixed.
-            name_formatter = function(buf)  -- buf contains a "name", "path" and "bufnr"
-                -- remove extension from markdown files for example
-                if buf.name:match('%.md') then
-                    return vim.fn.fnamemodify(buf.name, ':t:r')
-                end
+            name_formatter = function(buf)  -- buf contains:
+                  -- name           | str  | the basename of the active file
+                  -- path           | str  | the full path of the active file
+                  -- bufnr          | int  | the number of the active buffer
+                  -- extension      | str  | the file extension of the active file
+                  -- icon           | str  | the icon of the active file
+                  -- icon_highlight | str  | the highlight group of the active file
+                  -- ordinal        | int  | the ordinal number of the buffer/tab
+                  -- modified       | bool | whether the active file has unwritten changes
+                  -- modifiable     | bool | whether the active file is modifiable
+
+                  -- for tabs the following fiels are also included:
+                  -- tabnr          | int        | the number of the tab
+                  -- focusable      | bool       | whether the tab is focusable
+                  -- buffers        | table(int) | the numbers of the buffers in the tab
+                  -- hidden         | bool       | whether the tab is hidden
             end,
             max_name_length = 18,
             max_prefix_length = 15, -- prefix used when a buffer is de-duplicated

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -139,7 +139,22 @@ function Tabpage:new(tab)
     type = tab.buftype,
   })
   if tab.name_formatter and type(tab.name_formatter) == "function" then
-    tab.name = tab.name_formatter({ name = tab.name, path = tab.path, tabnr = tab.id }) or tab.name
+    tab.name = tab.name_formatter({
+      name           = tab.name,
+      path           = tab.path,
+      bufnr          = tab.buf,
+      extension      = tab.extension,
+      icon           = tab.icon,
+      icon_highlight = tab.icon_highlight,
+      ordinal        = tab.ordinal,
+      modified       = tab.modified,
+      modifiable     = tab.modifiable,
+
+      tabnr          = tab.id,
+      focusable      = tab.focusable,
+      buffers        = tab.buffers,
+      hidden         = tab.hidden,
+      }) or tab.name
   end
   setmetatable(tab, self)
   self.__index = self
@@ -221,7 +236,17 @@ function Buffer:new(buf)
     name = fn.fnamemodify(buf.path, ":t")
     name = is_directory and name .. "/" or name
     if buf.name_formatter and type(buf.name_formatter) == "function" then
-      name = buf.name_formatter({ name = name, path = buf.path, bufnr = buf.id }) or name
+      name = buf.name_formatter({
+        name = name,
+        path = buf.path,
+        bufnr = buf.id,
+        extension = buf.extension,
+        icon = buf.icon,
+        icon_highlight = buf.icon_highlight,
+        ordinal = buf.ordinal,
+        modified = buf.modified,
+        modifiable  = buf.modifiable
+      }) or name
     end
   end
   buf.name, buf.filename = name, name -- TODO: remove this 'filename' field


### PR DESCRIPTION
With this PR, the following fields will be passed to `name_formatter`

| Field            | Type   | Description                                   |
| ---------------- | ------ | --------------------------------------------- |
| name             | str    | the basename of the active file               |
| path             | str    | the full path of the active file              |
| bufnr            | int    | the number of the active buffer               |
| extension        | str    | the file extension of the active file         |
| icon             | str    | the icon of the active file                   |
| icon_highlight   | str    | the highlight group of the active file        |
| ordinal          | int    | the ordinal number of the buffer/tab          |
| modified         | bool   | whether the active file has unwritten changes |
| modifiable       | bool   | whether the active file is modifiable         |

for tabs the following fiels are also included:

| Field       | Type         | Description                             |
| ----------- | ------------ | --------------------------------------- |
| tabnr       | int          | the number of the tab                   |
| focusable   | bool         | whether the tab is focusable            |
| buffers     | table(int)   | the numbers of the buffers in the tab   |
| hidden      | bool         | whether the tab is hidden               |

