### PR TITLE
fix(custom_area): default = false for highlights

### DIFF
--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -21,7 +21,7 @@ local function create_hl(index, side, section, bg)
   local opts = highlights.translate_user_highlights(section)
   opts.bg = opts.bg or bg
   -- We need to be able to constantly override these highlights so they should always be default
-  opts.default = true
+  opts.default = false
   highlights.set_one(name, opts)
   return highlights.hl(name)
 end

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -119,7 +119,7 @@ end
 function M.set_one(name, opts)
   if not opts or vim.tbl_isempty(opts) then return end
   local hl = filter_invalid_keys(opts)
-  hl.default = vim.F.if_nil(opts.default, config.options.themable)
+  hl.default = vim.F.if_nil(opts.default, not config.options.themable)
   local ok, msg = pcall(api.nvim_set_hl, 0, name, hl)
   if ok then return hl end
   utils.notify(


### PR DESCRIPTION
Hello!

I noticed an issue in which the highlights in my dynamic custom areas were not updating conditionally while the text contents changed as expected. I dug deeper, and it seems that `default = true` is being passed to `vim.api.nvim_set_hl`, which does the _opposite_ of what the code comment states as the intention of setting it to `true`:

```lua
-- We need to be able to constantly override these highlights so they should always be default
opts.default = true
```

Changing `opts.default = false` seems to resolve my issue, and highlights update as expected in my custom areas.

Let me know if this needs any further editing or if I went down the wrong path and there's a simpler way to update custom area highlights. Thanks! :)

**Edit:** I noticed a similar issue with setting `config.options.themable`: the highlighting function treats `themable = true` as `default = true`, which means that the `themable` option doesn't allow for highlights to be overwritten after they are set once.