### PR TITLE
fix(commands): trigger redraw after delete in direction

### DIFF
--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -206,6 +206,7 @@ function M.close_in_direction(direction, force)
       delete_element(item.id, force)
     end
   end
+  ui.refresh()
 end
 
 --- sorts all elements


### PR DESCRIPTION
Hi! I made a PR to fix the bufferline not redrawing after calling `close_in_direction` from a keybinding :)

This will fix #586