### PR TITLE
feat(tabs): allow moving/reordering tabs

### DIFF
--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -20,27 +20,6 @@ local M = {}
 
 local api = vim.api
 
---- sorts buf_names in place, but doesn't add/remove any values
---- @param buf_nums number[]
---- @param sorted number[]
---- @return number[]
-local function get_updated_buffers(buf_nums, sorted)
-  if not sorted then return buf_nums end
-  local nums = { unpack(buf_nums) }
-  local reverse_lookup_sorted = utils.tbl_reverse_lookup(sorted)
-
-  --- a comparator that sorts buffers by their position in sorted
-  local sort_by_sorted = function(buf_id_1, buf_id_2)
-    local buf_1_rank = reverse_lookup_sorted[buf_id_1]
-    local buf_2_rank = reverse_lookup_sorted[buf_id_2]
-    if not buf_1_rank then return false end
-    if not buf_2_rank then return true end
-    return buf_1_rank < buf_2_rank
-  end
-  table.sort(nums, sort_by_sorted)
-  return nums
-end
-
 ---Filter the buffers to show based on the user callback passed in
 ---@param buf_nums integer[]
 ---@param callback fun(buf: integer, bufs: integer[]): boolean
@@ -62,7 +41,7 @@ function M.get_components(state)
   local buf_nums = utils.get_valid_buffers()
   local filter = options.custom_filter
   buf_nums = filter and apply_buffer_filter(buf_nums, filter) or buf_nums
-  buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
+  buf_nums = utils.apply_sort(buf_nums, state.custom_sort)
 
   pick.reset()
   duplicates.reset()

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -75,27 +75,6 @@ local function get_valid_tabs()
   )
 end
 
---- sorts tab_nums in place, but doesn't add/remove any values
---- @param tab_nums number[]
---- @param sorted number[]
---- @return number[]
-local function get_updated_tabs(tab_nums, sorted)
-  if not sorted then return tab_nums end
-  local nums = { unpack(tab_nums) }
-  local reverse_lookup_sorted = utils.tbl_reverse_lookup(sorted)
-
-  --- a comparator that sorts buffers by their position in sorted
-  local sort_by_sorted = function(buf_id_1, buf_id_2)
-    local buf_1_rank = reverse_lookup_sorted[buf_id_1]
-    local buf_2_rank = reverse_lookup_sorted[buf_id_2]
-    if not buf_1_rank then return false end
-    if not buf_2_rank then return true end
-    return buf_1_rank < buf_2_rank
-  end
-  table.sort(nums, sort_by_sorted)
-  return nums
-end
-
 ---Filter the buffers to show based on the user callback passed in
 ---@param buf_nums integer[]
 ---@param callback fun(buf: integer, bufs: integer[]): boolean
@@ -138,7 +117,7 @@ end
 function M.get_components(state)
   local options = config.options
   local tab_nums = get_valid_tabs()
-  tab_nums = get_updated_tabs(tab_nums, state.custom_sort)
+  tab_nums = utils.apply_sort(tab_nums, state.custom_sort)
 
   local Tabpage = models.Tabpage
   ---@type NvimTab[]

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -75,6 +75,27 @@ local function get_valid_tabs()
   )
 end
 
+--- sorts tab_nums in place, but doesn't add/remove any values
+--- @param tab_nums number[]
+--- @param sorted number[]
+--- @return number[]
+local function get_updated_tabs(tab_nums, sorted)
+  if not sorted then return tab_nums end
+  local nums = { unpack(tab_nums) }
+  local reverse_lookup_sorted = utils.tbl_reverse_lookup(sorted)
+
+  --- a comparator that sorts buffers by their position in sorted
+  local sort_by_sorted = function(buf_id_1, buf_id_2)
+    local buf_1_rank = reverse_lookup_sorted[buf_id_1]
+    local buf_2_rank = reverse_lookup_sorted[buf_id_2]
+    if not buf_1_rank then return false end
+    if not buf_2_rank then return true end
+    return buf_1_rank < buf_2_rank
+  end
+  table.sort(nums, sort_by_sorted)
+  return nums
+end
+
 ---Filter the buffers to show based on the user callback passed in
 ---@param buf_nums integer[]
 ---@param callback fun(buf: integer, bufs: integer[]): boolean
@@ -116,7 +137,8 @@ end
 ---@return NvimTab[]
 function M.get_components(state)
   local options = config.options
-  local tabs = get_valid_tabs()
+  local tab_nums = get_valid_tabs()
+  tab_nums = get_updated_tabs(tab_nums, state.custom_sort)
 
   local Tabpage = models.Tabpage
   ---@type NvimTab[]
@@ -126,7 +148,7 @@ function M.get_components(state)
 
   local filter = options.custom_filter
 
-  for i, tab_num in ipairs(tabs) do
+  for i, tab_num in ipairs(tab_nums) do
     local active_buf = get_active_buf_for_tab(tab_num)
     local buffers = get_tab_buffers(tab_num)
     local buffer

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -159,7 +159,7 @@ function M.apply_sort(to_sort, sorted)
   local ret = { unpack(to_sort) }
   local reverse_lookup_sorted = M.tbl_reverse_lookup(sorted)
 
-  --- a comparator that sorts buffers by their position in sorted
+  --- a comparator that sorts numbers by their position in sorted
   local sort_by_sorted = function(item1, item2)
     local item1_rank = reverse_lookup_sorted[item1]
     local item2_rank = reverse_lookup_sorted[item2]

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -147,6 +147,28 @@ function M.get_tab_count() return #fn.gettabinfo() end
 
 function M.close_tab(tabhandle) vim.cmd("tabclose " .. api.nvim_tabpage_get_number(tabhandle)) end
 
+---Sorts the given numbers in place, but doesn't add/remove any values.
+---Useful i.e. when sorting a list of buffer numbers or tab numbers.
+---@param to_sort number[]
+---@param sorted number[]
+---@return number[]
+function M.apply_sort(to_sort, sorted)
+  if not sorted then return to_sort end
+  local nums = { unpack(to_sort) }
+  local reverse_lookup_sorted = M.tbl_reverse_lookup(sorted)
+
+  --- a comparator that sorts buffers by their position in sorted
+  local sort_by_sorted = function(buf_id_1, buf_id_2)
+    local buf_1_rank = reverse_lookup_sorted[buf_id_1]
+    local buf_2_rank = reverse_lookup_sorted[buf_id_2]
+    if not buf_1_rank then return false end
+    if not buf_2_rank then return true end
+    return buf_1_rank < buf_2_rank
+  end
+  table.sort(nums, sort_by_sorted)
+  return nums
+end
+
 --- Wrapper around `vim.notify` that adds message metadata
 ---@param msg string | string[]
 ---@param level "error" | "warn" | "info" | "debug" | "trace"

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -147,26 +147,28 @@ function M.get_tab_count() return #fn.gettabinfo() end
 
 function M.close_tab(tabhandle) vim.cmd("tabclose " .. api.nvim_tabpage_get_number(tabhandle)) end
 
----Sorts the given numbers in place, but doesn't add/remove any values.
+---Sorts the given list of numbers.
+---Does NOT sort the list in-place, instead returns a new sorted list.
+---Does not add/remove any values.
 ---Useful i.e. when sorting a list of buffer numbers or tab numbers.
 ---@param to_sort number[]
 ---@param sorted number[]
 ---@return number[]
 function M.apply_sort(to_sort, sorted)
   if not sorted then return to_sort end
-  local nums = { unpack(to_sort) }
+  local ret = { unpack(to_sort) }
   local reverse_lookup_sorted = M.tbl_reverse_lookup(sorted)
 
   --- a comparator that sorts buffers by their position in sorted
-  local sort_by_sorted = function(buf_id_1, buf_id_2)
-    local buf_1_rank = reverse_lookup_sorted[buf_id_1]
-    local buf_2_rank = reverse_lookup_sorted[buf_id_2]
-    if not buf_1_rank then return false end
-    if not buf_2_rank then return true end
-    return buf_1_rank < buf_2_rank
+  local sort_by_sorted = function(item1, item2)
+    local item1_rank = reverse_lookup_sorted[item1]
+    local item2_rank = reverse_lookup_sorted[item2]
+    if not item1_rank then return false end
+    if not item2_rank then return true end
+    return item1_rank < item2_rank
   end
-  table.sort(nums, sort_by_sorted)
-  return nums
+  table.sort(ret, sort_by_sorted)
+  return ret
 end
 
 --- Wrapper around `vim.notify` that adds message metadata


### PR DESCRIPTION
Before this PR, when in tab mode, the commands `BufferLineMoveNext` or `BufferLineMovePrev` did not visually change any tab positionings in the UI. Now it will update in the UI.

### Before:

https://user-images.githubusercontent.com/52012721/196027505-feeac011-3cfe-4773-a031-dc9ff742fcf7.mov


### After:

https://user-images.githubusercontent.com/52012721/196027539-84d08805-0af8-4f7c-b04a-48e538780389.mov
