### PR TITLE
revert(tabs): allow moving/reordering tabs (#588)

### DIFF
--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -116,8 +116,7 @@ end
 ---@return NvimTab[]
 function M.get_components(state)
   local options = config.options
-  local tab_nums = get_valid_tabs()
-  tab_nums = utils.apply_sort(tab_nums, state.custom_sort)
+  local tabs = get_valid_tabs()
 
   local Tabpage = models.Tabpage
   ---@type NvimTab[]
@@ -127,7 +126,7 @@ function M.get_components(state)
 
   local filter = options.custom_filter
 
-  for i, tab_num in ipairs(tab_nums) do
+  for i, tab_num in ipairs(tabs) do
     local active_buf = get_active_buf_for_tab(tab_num)
     local buffers = get_tab_buffers(tab_num)
     local buffer

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -147,30 +147,6 @@ function M.get_tab_count() return #fn.gettabinfo() end
 
 function M.close_tab(tabhandle) vim.cmd("tabclose " .. api.nvim_tabpage_get_number(tabhandle)) end
 
----Sorts the given list of numbers.
----Does NOT sort the list in-place, instead returns a new sorted list.
----Does not add/remove any values.
----Useful i.e. when sorting a list of buffer numbers or tab numbers.
----@param to_sort number[]
----@param sorted number[]
----@return number[]
-function M.apply_sort(to_sort, sorted)
-  if not sorted then return to_sort end
-  local ret = { unpack(to_sort) }
-  local reverse_lookup_sorted = M.tbl_reverse_lookup(sorted)
-
-  --- a comparator that sorts numbers by their position in sorted
-  local sort_by_sorted = function(item1, item2)
-    local item1_rank = reverse_lookup_sorted[item1]
-    local item2_rank = reverse_lookup_sorted[item2]
-    if not item1_rank then return false end
-    if not item2_rank then return true end
-    return item1_rank < item2_rank
-  end
-  table.sort(ret, sort_by_sorted)
-  return ret
-end
-
 --- Wrapper around `vim.notify` that adds message metadata
 ---@param msg string | string[]
 ---@param level "error" | "warn" | "info" | "debug" | "trace"


### PR DESCRIPTION
This reverts commit b4db22d86fcc08e774b6208d0eb8bd59fc521bb0.

See discussion here: https://github.com/akinsho/bufferline.nvim/pull/588#issuecomment-1282145111