### PR TITLE
feat(tabs): sort by tab number instead of tab id

### DIFF
--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -779,10 +779,7 @@ function Config:resolve(defaults)
 
   if self:is_tabline() then
     local opts = defaults.options
-    -- If the sort by mechanism is "tabs" but the user is in tabline mode
-    -- then the id will be that of the tabs so sort by should be id i.e. "tabs" sort
-    -- is redundant in tabs mode
-    if opts.sort_by == "tabs" then opts.sort_by = "id" end
+    opts.sort_by = "tabs"
     if opts.show_tab_indicators then opts.show_tab_indicators = false end
     opts.close_command = utils.close_tab
     opts.right_mouse_command = "tabclose %d"

--- a/lua/bufferline/sorters.lua
+++ b/lua/bufferline/sorters.lua
@@ -57,6 +57,12 @@ end
 
 --- @param buf_a NvimBuffer
 --- @param buf_b NvimBuffer
+local function sort_by_tabpage_number(buf_a, buf_b)
+  local a = vim.api.nvim_tabpage_get_number(buf_a.id)
+  local b = vim.api.nvim_tabpage_get_number(buf_b.id)
+  return a < b
+end
+
 local function sort_by_tabs(buf_a, buf_b)
   local buf_a_tabnr = init_buffer_tabnr(buf_a)
   local buf_b_tabnr = init_buffer_tabnr(buf_b)
@@ -139,7 +145,7 @@ function M.sort(elements, sort_by, state)
   elseif sort_by == "id" then
     table.sort(elements, sort_by_id)
   elseif sort_by == "tabs" then
-    table.sort(elements, sort_by_tabs)
+    table.sort(elements, config:is_tabline() and sort_by_tabpage_number or sort_by_tabs)
   elseif type(sort_by) == "function" then
     table.sort(elements, sort_by)
   end

--- a/lua/bufferline/sorters.lua
+++ b/lua/bufferline/sorters.lua
@@ -139,7 +139,7 @@ function M.sort(elements, sort_by, state)
   elseif sort_by == "id" then
     table.sort(elements, sort_by_id)
   elseif sort_by == "tabs" then
-    table.sort(elements, config:is_tabline() and sort_by_id or sort_by_tabs)
+    table.sort(elements, sort_by_tabs)
   elseif type(sort_by) == "function" then
     table.sort(elements, sort_by)
   end


### PR DESCRIPTION
Bufferline currently sorts tabs by id (neovim internal handle) instead of my number (vim user sorted tabpages). Bufferlines `sort_by_tabs` already properly sorts this. This PR applies `sort_by_tabs` by default for tab users.