### PR TITLE
fix(utils): get icon by filetype when get icon by filename not exist

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -186,15 +186,12 @@ function M.get_icon(opts)
 
   local use_default = config.options.show_buffer_default_icon
 
-  local icon, hl
-  if M.is_truthy(opts.filetype) then
-    -- Don't use a default here so that we fall through to the next case if no icon is found
+  local icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension, {
+    default = use_default,
+  })
+
+  if M.is_truthy(opts.filetype) and not icon then
     icon, hl = webdev_icons.get_icon_by_filetype(opts.filetype, { default = false })
-  end
-  if not icon then
-    icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension, {
-      default = use_default,
-    })
   end
 
   if not icon then return "", "" end


### PR DESCRIPTION
I think get icon by filetype should be fallback of get icon by filename/extension.
Before:
![before](https://user-images.githubusercontent.com/64405319/198540464-f87459e0-0ad6-4e77-a493-c53d0829e4bf.png)
After:
![after](https://user-images.githubusercontent.com/64405319/198540483-c8d315c4-0b6d-4556-b79c-133564aa2532.png)
