### PR TITLE
Add a new separator to show hidden built-in groups

### DIFF
--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -114,6 +114,16 @@ end
 ---@type GroupSeparator
 function separator.none() return { sep_start = {}, sep_end = {} } end
 
+---@param group Group,
+---@param hls  table<string, table<string, string>>
+---@param count string
+---@return Separators
+---@type GroupSeparator
+function separator.hidden_only(group, hls, count)
+  if group.hidden then return separator.pill(group, hls, count) end
+  return separator.none()
+end
+
 ----------------------------------------------------------------------------------------------------
 -- BUILTIN GROUPS
 ----------------------------------------------------------------------------------------------------
@@ -150,7 +160,7 @@ builtin.ungrouped = Group:new({
   id = UNGROUPED_ID,
   name = UNGROUPED_NAME,
   separator = {
-    style = separator.none,
+    style = separator.hidden_only,
   },
 })
 
@@ -160,7 +170,7 @@ builtin.pinned = Group:new({
   icon = "📌",
   priority = 1,
   separator = {
-    style = separator.none,
+    style = separator.hidden_only,
   },
 })
 


### PR DESCRIPTION
<img width="986" alt="image" src="https://user-images.githubusercontent.com/11025519/199318188-c06f572f-97d1-4e76-b993-7b1100eb8d3c.png">

This is an example of my buffers, when I hid the built-in `ungrouped` and `pinned` groups, they disappeared. It's a bit confusing, and after a while, people may forget the hidden groups.

And after the changes,

<img width="669" alt="image" src="https://user-images.githubusercontent.com/11025519/199322630-dad597c9-860e-4337-b14d-05086901a2da.png">

