### PR TITLE
fix(tabs): show unnamed buffers

### DIFF
--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -64,7 +64,10 @@ end
 ---@param buf integer
 ---@return string
 local function get_buffer_name(buf)
-  local name = (buf and api.nvim_buf_is_valid(buf)) and api.nvim_buf_get_name(buf) or "[No name]"
+  local name = (buf and api.nvim_buf_is_valid(buf)) and api.nvim_buf_get_name(buf)
+  if not name or name == "" then
+    name = "[No Name]"
+  end
   return name
 end
 


### PR DESCRIPTION
In tabs mode, unnamed buffers do not have any name appear in the tabline. This is in contrast to buffers mode, where they appear as "No Name." It seems the infrastructure to do this was implemented, but it didn't work due to a logic error caused by the assumption that the empty string is treated as falsy in Lua.