### PR TITLE
fix(hover): check showtabline not laststatus

### DIFF
--- a/lua/bufferline/hover.lua
+++ b/lua/bufferline/hover.lua
@@ -10,7 +10,7 @@ local previous_pos = nil
 local M = {}
 
 local function on_hover(current)
-  if vim.o.laststatus == 0 then return end
+  if vim.o.showtabline == 0 then return end
   if current.screenrow == 1 then
     api.nvim_exec_autocmds("User", {
       pattern = "BufferLineHoverOver",


### PR DESCRIPTION
There is not really a point in gatekeeping this feature from `laststatus=0`.
The hover feature works completely fine with `laststatus=0` and this creates only problems with other plugins, see: https://github.com/vimpostor/vim-tpipeline/issues/39