### PR TITLE
add tabpage renaming

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -191,7 +191,7 @@ You can change the appearance of the bufferline separators by setting the
 
 
 ==============================================================================
-TABPAGES                                                          *bufferline-tabs*
+TABPAGES                                                   *bufferline-tabpages*
 
 This plugin can also be set to show only tabpages. This can be done by setting
 the `mode` option to `tabs`. This will change the bufferline to a tabline it
@@ -200,6 +200,15 @@ has a lot of the same features/styling but not all. A few things to note are
 * Sorting doesn't work yet as that needs to be thought through.
 * Grouping doesn't work yet as that also needs to be thought through.
 
+`BufferLineRenameTab`
+
+Tabs can be renamed via `BufferLineRenameTab`:
+`BufferLineRenameTab 0 Project name`
+or
+`BufferLineRenameTab 1 Project name`
+
+If the first argument is `0` or is not present, the current tab will be
+modified. Otherwise, the tab number specified will be modified.
 
 ==============================================================================
 NUMBERS                                                    *bufferline-numbers*

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -43,6 +43,7 @@ local M = {
   get_elements = commands.get_elements,
   close_with_pick = commands.close_with_pick,
   close_in_direction = commands.close_in_direction,
+  rename_tab = commands.rename_tab,
   -- @deprecate
   go_to_buffer = commands.go_to,
   sort_buffers_by = commands.sort_by,
@@ -253,6 +254,9 @@ local function setup_commands()
     { nargs = 1, complete = complete_groups }
   )
   cmd("BufferLineTogglePin", function() M.toggle_pin() end, { nargs = 0 })
+  cmd("BufferLineRenameTab", function(opts)
+        M.rename_tab(opts.fargs)
+    end, { nargs = '*' })
 end
 
 ---@private

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -18,6 +18,8 @@ local sorters = lazy.require("bufferline.sorters")
 local constants = lazy.require("bufferline.constants")
 ---@module "bufferline.pick"
 local pick = lazy.require("bufferline.pick")
+---@module "bufferline.tabpages"
+local tabpage = lazy.require("bufferline.tabpages")
 
 local M = {}
 
@@ -121,6 +123,17 @@ function M.pick() pick.choose_then(open_element) end
 
 function M.close_with_pick()
   pick.choose_then(function(id) handle_close(id) end)
+end
+
+function M.rename_tab(args)
+    if #args == 0 then return end
+    local tabnr = tonumber(args[1])
+    local name = args[2]
+    if tabnr == nil then
+        name = args[1]
+        tabnr = 0
+    end
+    tabpage.rename_tab(tabnr, name)
 end
 
 --- Open a element based on it's visible position in the list

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -128,9 +128,9 @@ end
 function M.rename_tab(args)
     if #args == 0 then return end
     local tabnr = tonumber(args[1])
-    local name = args[2]
+    local name = table.concat(args, " ",2)
     if tabnr == nil then
-        name = args[1]
+        name = table.concat(args, " ")
         tabnr = 0
     end
     tabpage.rename_tab(tabnr, name)

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -41,9 +41,10 @@ function M.rename_tab(tabnr, name)
   if tabnr == 0 then
     tabnr = vim.fn.tabpagenr()
   end
-
+  if name == "" then
+    name = ""..tabnr..""
+  end
   vim.api.nvim_tabpage_set_var(tabnr, "name", name)
-
   M.get()
 end
 

--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -30,11 +30,21 @@ local function render(tabpage, is_active, style, highlights)
   local separator_hl = is_active and h.tab_separator_selected.hl_group or h.tab_separator.hl_group
   local chars = constants.sep_chars[style] or constants.sep_chars.thin
   local separator_component = chars[2]
-  local name = padding .. padding .. tabpage.tabnr .. padding
+  local name = padding .. padding .. (tabpage.variables.name or tabpage.tabnr) .. padding
   return {
     { highlight = hl, text = name, attr = { prefix = tab_click_component(tabpage.tabnr) } },
     { highlight = separator_hl, text = separator_component },
   }
+end
+
+function M.rename_tab(tabnr, name)
+  if tabnr == 0 then
+    tabnr = vim.fn.tabpagenr()
+  end
+
+  vim.api.nvim_tabpage_set_var(tabnr, "name", name)
+
+  M.get()
 end
 
 function M.get()


### PR DESCRIPTION
Fixes #634 

The name can be set like so:
```lua
-- Set's current tab to "something"
require('bufferline.tabpages').rename_tab(0, "something")
-- Set's tab 1 to "asdf"
require('bufferline.tabpages').rename_tab(1, "asdf")
```
or
```vim
" both of these are equivalent 
:BufferLineRenameTab something
" or
:BufferLineRenameTab 0 something
```
All remaining arguments to `BufferLineRenameTab` are taken as the name:
```vim
" This will rename tab 1 to "this is project 1"
:BufferLineRenameTab 1 this is project 1
```

Example result:
![bufferline-tabline-rename](https://user-images.githubusercontent.com/49327592/207974670-ca056a24-ae38-481b-80ca-5645a5dfd8b4.png)

