### PR TITLE
docs(bufferline.txt): add missing comma to docs

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -537,7 +537,7 @@ for left or right aligned sidebar windows such as `NvimTree`, `NERDTree` or
         {
             filetype = "NvimTree",
             text = "File Explorer",
-            highlight = "Directory"
+            highlight = "Directory",
             separator = true -- use a "true" to enable the default, or set your own character
         }
     }


### PR DESCRIPTION
Noticed a comma was missing when I was looking through the docs, so I added it :)