### PR TITLE
refactor(tabs): only show close icon if multiple tabse

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -537,7 +537,7 @@ for left or right aligned sidebar windows such as `NvimTree`, `NERDTree` or
         {
             filetype = "NvimTree",
             text = "File Explorer",
-            highlight = "Directory"
+            highlight = "Directory",
             separator = true -- use a "true" to enable the default, or set your own character
         }
     }

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -150,6 +150,7 @@ The available configuration are:
             sort_by = 'insert_after_current' |'insert_at_end' | 'id' | 'extension' | 'relative_directory' | 'directory' | 'tabs' | function(buffer_a, buffer_b)
                 -- add custom logic
                 return buffer_a.modified > buffer_b.modified
+            always_show_tab_close_icon = true | false, -- if false the tab close icon will only appear if there is more than one tab
             end
         }
     }

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -150,7 +150,6 @@ The available configuration are:
             sort_by = 'insert_after_current' |'insert_at_end' | 'id' | 'extension' | 'relative_directory' | 'directory' | 'tabs' | function(buffer_a, buffer_b)
                 -- add custom logic
                 return buffer_a.modified > buffer_b.modified
-            always_show_tab_close_icon = true | false, -- if false the tab close icon will only appear if there is more than one tab
             end
         }
     }

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -308,8 +308,8 @@ In order to group buffers specify a list of groups in your config e.g.
         end,
       }
       {
-        name = "Docs"
-        highlight = {undercurl = true, sp = green},
+        name = "Docs",
+        highlight = {undercurl = true, sp = "green"},
         auto_close = false,  -- whether or not close this group if it doesn't contain the current buffer
         matcher = function(buf)
           return buf.filename:match('%.md') or buf.filename:match('%.txt')

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -717,15 +717,23 @@ function M.tabline(items, tab_indicators)
   local left_marker = get_trunc_marker(left_trunc_icon, fill, fill, marker.left_count)
   local right_marker = get_trunc_marker(right_trunc_icon, fill, fill, marker.right_count)
 
-  local core = join(
-    utils.merge_lists(
-      { left_marker },
-      segments,
-      { right_marker, right_align },
-      tab_indicator_segments,
-      { tab_close_button }
-    )
+  local merged = utils.merge_lists(
+    { left_marker },
+    segments,
+    { right_marker, right_align }
   )
+  if (vim.api.nvim_eval('tabpagenr("$")') > 1 or options.always_show_tab_close_icon)
+  then
+    merged = utils.merge_lists(
+        { left_marker },
+        segments,
+        { right_marker, right_align },
+        tab_indicator_segments,
+        { tab_close_button }
+    )
+  end
+
+  local core = join(merged)
 
   --- NOTE: the custom areas are essentially mini tablines a user can define so they can't
   -- be set safely converted to segments so they are concatenated to string and join with

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -193,7 +193,7 @@ end
 ---@param hls BufferlineHighlights
 ---@return Segment[]
 local function get_tab_close_button(options, hls)
-  if options.show_close_icon then
+  if options.show_close_icon and (#vim.api.nvim_list_tabpages() > 1) then
     return {
       {
         text = padding .. options.close_icon .. padding,
@@ -717,23 +717,15 @@ function M.tabline(items, tab_indicators)
   local left_marker = get_trunc_marker(left_trunc_icon, fill, fill, marker.left_count)
   local right_marker = get_trunc_marker(right_trunc_icon, fill, fill, marker.right_count)
 
-  local merged = utils.merge_lists(
-    { left_marker },
-    segments,
-    { right_marker, right_align }
-  )
-  if (vim.api.nvim_eval('tabpagenr("$")') > 1 or options.always_show_tab_close_icon)
-  then
-    merged = utils.merge_lists(
-        { left_marker },
-        segments,
-        { right_marker, right_align },
-        tab_indicator_segments,
-        { tab_close_button }
+  local core = join(
+    utils.merge_lists(
+      { left_marker },
+      segments,
+      { right_marker, right_align },
+      tab_indicator_segments,
+      { tab_close_button }
     )
-  end
-
-  local core = join(merged)
+  )
 
   --- NOTE: the custom areas are essentially mini tablines a user can define so they can't
   -- be set safely converted to segments so they are concatenated to string and join with


### PR DESCRIPTION
The tab close icon can look a little odd (and won't do anything) if there's only one tab in use. See [this reddit post ](https://www.reddit.com/r/neovim/comments/v9211b/can_we_remove_the_x_on_the_right_side_of_the/)

Since I would guess many people who use this plugin would be less inclined to use standard vim tabs - I thought it would make sense and improve aesthetics to remove it if there's only one tab in use (it will reappear if the user opens another tab). For those who want to always see the tab close icon, the `always_show_tab_close_icon` option can be set to `true` in setup (default is `false`). 

Please let me know your thought and btw I love this plugin :)

