### PR TITLE
fix(get_icon): always use `get_icon` API of devicons

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -184,6 +184,9 @@ function M.get_icon(opts)
   end
   if type == "terminal" then return webdev_icons.get_icon(type) end
 
+  -- NOTE(#549): hack filetype might use the same extension as php, so prioritize filetype based icon look up in that case
+  if opts.filetype == "hack" then return webdev_icons.get_icon_by_filetype(opts.filetype) end
+
   local use_default = config.options.show_buffer_default_icon
   local icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension, {
     -- Don't use a default here so that we fall through to the next case if no icon is found

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -185,17 +185,9 @@ function M.get_icon(opts)
   if type == "terminal" then return webdev_icons.get_icon(type) end
 
   local use_default = config.options.show_buffer_default_icon
-
-  local icon, hl
-  if M.is_truthy(opts.filetype) then
-    -- Don't use a default here so that we fall through to the next case if no icon is found
-    icon, hl = webdev_icons.get_icon_by_filetype(opts.filetype, { default = false })
-  end
-  if not icon then
-    icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension, {
-      default = use_default,
-    })
-  end
+  local icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension, {
+    default = use_default,
+  })
 
   if not icon then return "", "" end
   return icon, hl

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -186,8 +186,12 @@ function M.get_icon(opts)
 
   local use_default = config.options.show_buffer_default_icon
   local icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension, {
-    default = use_default,
+    -- Don't use a default here so that we fall through to the next case if no icon is found
+    default = false,
   })
+  if icon == nil then
+    icon, hl = webdev_icons.get_icon_by_filetype(opts.filetype, { default = use_default })
+  end
 
   if not icon then return "", "" end
   return icon, hl


### PR DESCRIPTION
This API has better icon matching. As an example, `package.json` would have a generic json icon before this commit, but now it gets the specific PackageJson icon and highlight.

Before:

![before](https://user-images.githubusercontent.com/91974155/210437247-e490a620-b04a-47f7-820b-926145bd617a.png)

After:

![after](https://user-images.githubusercontent.com/91974155/210437292-dbe12306-936a-4fe7-b1a8-877d370d79cb.png)