### PR TITLE
docs(help): add a missing comma

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -537,7 +537,7 @@ for left or right aligned sidebar windows such as `NvimTree`, `NERDTree` or
         {
             filetype = "NvimTree",
             text = "File Explorer",
-            highlight = "Directory"
+            highlight = "Directory",
             separator = true -- use a "true" to enable the default, or set your own character
         }
     }

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -308,8 +308,8 @@ In order to group buffers specify a list of groups in your config e.g.
         end,
       }
       {
-        name = "Docs"
-        highlight = {undercurl = true, sp = green},
+        name = "Docs",
+        highlight = {undercurl = true, sp = "green"},
         auto_close = false,  -- whether or not close this group if it doesn't contain the current buffer
         matcher = function(buf)
           return buf.filename:match('%.md') or buf.filename:match('%.txt')

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -306,7 +306,7 @@ In order to group buffers specify a list of groups in your config e.g.
         matcher = function(buf) -- Mandatory
           return buf.filename:match('%_test') or buf.filename:match('%_spec')
         end,
-      }
+      },
       {
         name = "Docs",
         highlight = {undercurl = true, sp = "green"},


### PR DESCRIPTION
The syntax was wrong, I fixed it.