### PR TITLE
docs: update config type annotations

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -537,7 +537,7 @@ for left or right aligned sidebar windows such as `NvimTree`, `NERDTree` or
         {
             filetype = "NvimTree",
             text = "File Explorer",
-            highlight = "Directory"
+            highlight = "Directory",
             separator = true -- use a "true" to enable the default, or set your own character
         }
     }

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -308,8 +308,8 @@ In order to group buffers specify a list of groups in your config e.g.
         end,
       }
       {
-        name = "Docs"
-        highlight = {undercurl = true, sp = green},
+        name = "Docs",
+        highlight = {undercurl = true, sp = "green"},
         auto_close = false,  -- whether or not close this group if it doesn't contain the current buffer
         matcher = function(buf)
           return buf.filename:match('%.md') or buf.filename:match('%.txt')

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -41,7 +41,7 @@ local constants = lazy.require("bufferline.constants")
 ---@field public mode BufferlineMode
 ---@field public view string
 ---@field public debug DebugOpts
----@field public numbers string
+---@field public numbers string | fun(ordinal: number, id: number, lower: number_helper, raise: number_helper): string
 ---@field public buffer_close_icon string
 ---@field public modified_icon string
 ---@field public close_icon string
@@ -53,7 +53,7 @@ local constants = lazy.require("bufferline.constants")
 ---@field public indicator BufferlineIndicator
 ---@field public left_trunc_marker string
 ---@field public right_trunc_marker string
----@field public separator_style string
+---@field public separator_style string | {[1]: string, [2]: string}
 ---@field public name_formatter (fun(path: string):string)?
 ---@field public tab_size number
 ---@field public truncate_names boolean


### PR DESCRIPTION
Adds missing types to config fields.

Though in case of the separator style id did just a quick scan through the code base, I can not 100% verify if the string dict is the right union type . But it seemed fine to me.