### PR TITLE
feat: allow moving buffers to arbitrary positions

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -697,12 +697,16 @@ A few of this plugins commands can be mapped for ease of use. >
     nnoremap <silent><mymap> :BufferLineMoveNext<CR>
     nnoremap <silent><mymap> :BufferLineMovePrev<CR>
 
+    " These commands will move the current buffer to the first or the last position in the bufferline
+    nnoremap <silent><mymap> :BufferLineMoveToFirst<CR>
+    nnoremap <silent><mymap> :BufferLineMoveToLast<CR>
+
     " These commands will sort buffers by directory, language, or a custom criteria
     nnoremap <silent>be :BufferLineSortByExtension<CR>
     nnoremap <silent>bd :BufferLineSortByDirectory<CR>
     nnoremap <silent><mymap> :lua require'bufferline'.sort_buffers_by(function (buf_a, buf_b) return buf_a.id < buf_b.id end)<CR>
 
-If you manually arrange your buffers using `:BufferLineMove{Prev|Next}` during an nvim session this can be persisted for the session.
+If you manually arrange your buffers using `:BufferLineMove{Prev|Next|ToFirst|ToLast}` during an nvim session this can be persisted for the session.
 This is enabled by default but you need to ensure that your `sessionoptions+=globals` otherwise the session file will
 not track global variables which is the mechanism used to store your sort order.
 

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -697,16 +697,12 @@ A few of this plugins commands can be mapped for ease of use. >
     nnoremap <silent><mymap> :BufferLineMoveNext<CR>
     nnoremap <silent><mymap> :BufferLineMovePrev<CR>
 
-    " These commands will move the current buffer to the first or the last position in the bufferline
-    nnoremap <silent><mymap> :BufferLineMoveToFirst<CR>
-    nnoremap <silent><mymap> :BufferLineMoveToLast<CR>
-
     " These commands will sort buffers by directory, language, or a custom criteria
     nnoremap <silent>be :BufferLineSortByExtension<CR>
     nnoremap <silent>bd :BufferLineSortByDirectory<CR>
     nnoremap <silent><mymap> :lua require'bufferline'.sort_buffers_by(function (buf_a, buf_b) return buf_a.id < buf_b.id end)<CR>
 
-If you manually arrange your buffers using `:BufferLineMove{Prev|Next|ToFirst|ToLast}` during an nvim session this can be persisted for the session.
+If you manually arrange your buffers using `:BufferLineMove{Prev|Next}` during an nvim session this can be persisted for the session.
 This is enabled by default but you need to ensure that your `sessionoptions+=globals` otherwise the session file will
 not track global variables which is the mechanism used to store your sort order.
 

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -697,6 +697,10 @@ A few of this plugins commands can be mapped for ease of use. >
     nnoremap <silent><mymap> :BufferLineMoveNext<CR>
     nnoremap <silent><mymap> :BufferLineMovePrev<CR>
 
+    " These commands will move the current buffer to the first or the last position in the bufferline
+    nnoremap <silent><mymap> :lua require'bufferline'.move_to(1)<CR>
+    nnoremap <silent><mymap> :lua require'bufferline'.move_to(-1)<CR>
+
     " These commands will sort buffers by directory, language, or a custom criteria
     nnoremap <silent>be :BufferLineSortByExtension<CR>
     nnoremap <silent>bd :BufferLineSortByDirectory<CR>

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -35,6 +35,7 @@ local BUFFERLINE_GROUP = "BufferlineCmds"
 
 local M = {
   move = commands.move,
+  move_to = commands.move_to,
   exec = commands.exec,
   go_to = commands.go_to,
   cycle = commands.cycle,
@@ -233,6 +234,8 @@ local function setup_commands()
   cmd("BufferLineCloseLeft", function() M.close_in_direction("left") end, {})
   cmd("BufferLineMoveNext", function() M.move(1) end, {})
   cmd("BufferLineMovePrev", function() M.move(-1) end, {})
+  cmd("BufferLineMoveToFirst", function() M.move_to(1) end, {})
+  cmd("BufferLineMoveToLast", function() M.move_to(-1) end, {})
   cmd("BufferLineSortByExtension", function() M.sort_buffers_by("extension") end, {})
   cmd("BufferLineSortByDirectory", function() M.sort_buffers_by("directory") end, {})
   cmd(

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -234,8 +234,6 @@ local function setup_commands()
   cmd("BufferLineCloseLeft", function() M.close_in_direction("left") end, {})
   cmd("BufferLineMoveNext", function() M.move(1) end, {})
   cmd("BufferLineMovePrev", function() M.move(-1) end, {})
-  cmd("BufferLineMoveToFirst", function() M.move_to(1) end, {})
-  cmd("BufferLineMoveToLast", function() M.move_to(-1) end, {})
   cmd("BufferLineSortByExtension", function() M.sort_buffers_by("extension") end, {})
   cmd("BufferLineSortByDirectory", function() M.sort_buffers_by("directory") end, {})
   cmd(

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -166,6 +166,23 @@ function M.move(direction)
   end
 end
 
+--- @param buffer_index number
+function M.move_to(buffer_index)
+  local index = M.get_current_element_index(state)
+  if not index then return utils.notify("Unable to find buffer to move, sorry", "warn") end
+  local next_index = buffer_index > 0 and buffer_index or #state.components + 1 + buffer_index
+  if next_index >= 1 and next_index <= #state.components then
+    local item = state.components[index]
+    local destination_buf = state.components[next_index]
+    state.components[next_index] = item
+    state.components[index] = destination_buf
+    state.custom_sort = get_ids(state.components)
+    local opts = config.options
+    if opts.persist_buffer_sort then save_positions(state.custom_sort) end
+    ui.refresh()
+  end
+end
+
 function M.cycle(direction)
   if vim.opt.showtabline == 0 then
     if direction > 0 then vim.cmd("bnext") end

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -149,11 +149,12 @@ function M.get_current_element_index(current_state, opts)
   end
 end
 
---- @param buffer_index number
-function M.move_to(buffer_index)
-  local index = M.get_current_element_index(state)
+--- @param to_index number
+--- @param from_index number?
+function M.move_to(to_index, from_index)
+  local index = from_index or M.get_current_element_index(state)
   if not index then return utils.notify("Unable to find buffer to move, sorry", "warn") end
-  local next_index = buffer_index > 0 and buffer_index or #state.components + 1 + buffer_index
+  local next_index = to_index > 0 and to_index or #state.components + 1 + to_index
   if next_index >= 1 and next_index <= #state.components then
     local item = state.components[index]
     local destination_buf = state.components[next_index]
@@ -169,7 +170,7 @@ end
 --- @param direction number
 function M.move(direction)
   local index = M.get_current_element_index(state)
-  M.move_to(index + direction)
+  M.move_to(index + direction, index)
 end
 
 function M.cycle(direction)

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -149,11 +149,13 @@ function M.get_current_element_index(current_state, opts)
   end
 end
 
---- @param to_index number
+--- Move the buffer at index `from_index` (or current index if not specified) to position `to_index`
+--- @param to_index number negative indices are accepted (counting from the right instead of the left, e.g. -1 for the last position, -2 for the second-last, etc.)
 --- @param from_index number?
 function M.move_to(to_index, from_index)
   local index = from_index or M.get_current_element_index(state)
   if not index then return utils.notify("Unable to find buffer to move, sorry", "warn") end
+  -- Calculate next index depending on the sign of `to_index`
   local next_index = to_index > 0 and to_index or #state.components + 1 + to_index
   if next_index >= 1 and next_index <= #state.components then
     local item = state.components[index]

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -149,23 +149,6 @@ function M.get_current_element_index(current_state, opts)
   end
 end
 
---- @param direction number
-function M.move(direction)
-  local index = M.get_current_element_index(state)
-  if not index then return utils.notify("Unable to find buffer to move, sorry", "warn") end
-  local next_index = index + direction
-  if next_index >= 1 and next_index <= #state.components then
-    local item = state.components[index]
-    local destination_buf = state.components[next_index]
-    state.components[next_index] = item
-    state.components[index] = destination_buf
-    state.custom_sort = get_ids(state.components)
-    local opts = config.options
-    if opts.persist_buffer_sort then save_positions(state.custom_sort) end
-    ui.refresh()
-  end
-end
-
 --- @param buffer_index number
 function M.move_to(buffer_index)
   local index = M.get_current_element_index(state)
@@ -181,6 +164,12 @@ function M.move_to(buffer_index)
     if opts.persist_buffer_sort then save_positions(state.custom_sort) end
     ui.refresh()
   end
+end
+
+--- @param direction number
+function M.move(direction)
+  local index = M.get_current_element_index(state)
+  M.move_to(index + direction)
 end
 
 function M.cycle(direction)


### PR DESCRIPTION
I added a `move_to` function and `BufferLineMoveTo{First|Last}` commands so one can easily move the current buffer to the `n`-th position in the bufferline.

It's a bit like `:tabmove` but for buffers.

`move_to` takes an 1-based buffer index. Negative integers are allowed but 0 is ignored.

---

P.S. This is an awesome project! Thank you to all the maintainers for putting in so much time and effort to make this possible. I'm really enjoying using it and I'm so grateful for all the work that went into it. Keep up the great work!"
