### PR TITLE
feat(icons): add `get_element_icon` option

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -130,6 +130,7 @@ The available configuration are:
                 }
             },
             color_icons = true | false, -- whether or not to add the filetype icon highlights
+            load_icons_from_filetype = true | false, -- load devicons from filetype
             show_buffer_icons = true | false, -- disable filetype icons for buffers
             show_buffer_close_icons = true | false,
             show_buffer_default_icon = true | false, -- whether or not an unrecognised filetype should show a default icon

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -130,7 +130,17 @@ The available configuration are:
                 }
             },
             color_icons = true | false, -- whether or not to add the filetype icon highlights
-            load_icons_from_filetype = true | false, -- load devicons from filetype
+            get_element_icon = function(element)
+              -- element consists of {filetype: string, path: string, extension: string, directory: string}
+              -- This can be used to change how bufferline fetches the icon
+              -- for an element e.g. a buffer or a tab.
+              -- e.g.
+              local icon, hl = require('nvim-web-devicons').get_icon_by_filetype(opts.filetype, { default = false })
+              return icon, hl
+              -- or
+              local custom_map = {my_thing_ft: {icon = "my_thing_icon", hl}}
+              return custom_map[element.filetype]
+            end,
             show_buffer_icons = true | false, -- disable filetype icons for buffers
             show_buffer_close_icons = true | false,
             show_buffer_default_icon = true | false, -- whether or not an unrecognised filetype should show a default icon

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -727,6 +727,7 @@ local function get_defaults()
     tab_size = 18,
     max_name_length = 18,
     color_icons = true,
+    load_icons_from_filetype = true,
     show_buffer_icons = true,
     show_buffer_close_icons = true,
     show_buffer_default_icon = true,

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -32,10 +32,8 @@ local constants = lazy.require("bufferline.constants")
 
 ---@alias DiagnosticIndicator fun(count: number, level: number, errors: table<string, any>, ctx: table<string, any>): string
 
----@class HoverOptions
----@field reveal string[]
----@field delay integer
----@field enabled boolean
+---@alias HoverOptions {reveal: string[], delay: integer, enabled: boolean}
+---@alias IconFetcherOpts {directory: boolean, path: string, extension: string, filetype: string?}
 
 ---@class BufferlineOptions
 ---@field public mode BufferlineMode
@@ -62,6 +60,7 @@ local constants = lazy.require("bufferline.constants")
 ---@field public show_buffer_icons boolean
 ---@field public show_buffer_close_icons boolean
 ---@field public show_buffer_default_icon boolean
+---@field public get_element_icon fun(opts: IconFetcherOpts): string?, string?
 ---@field public show_close_icon boolean
 ---@field public show_tab_indicators boolean
 ---@field public show_duplicate_prefix boolean
@@ -727,9 +726,10 @@ local function get_defaults()
     tab_size = 18,
     max_name_length = 18,
     color_icons = true,
-    load_icons_from_filetype = true,
     show_buffer_icons = true,
     show_buffer_close_icons = true,
+    get_element_icon = nil,
+    ---@deprecated
     show_buffer_default_icon = true,
     show_close_icon = true,
     show_tab_indicators = true,

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -187,7 +187,7 @@ function M.get_icon(opts)
   local use_default = config.options.show_buffer_default_icon
 
   local icon, hl
-  if M.is_truthy(opts.filetype) then
+  if M.is_truthy(opts.filetype) and M.is_truthy(config.options.load_icons_from_filetype) then
     -- Don't use a default here so that we fall through to the next case if no icon is found
     icon, hl = webdev_icons.get_icon_by_filetype(opts.filetype, { default = false })
   end

--- a/tests/bufferline_spec.lua
+++ b/tests/bufferline_spec.lua
@@ -53,6 +53,19 @@ describe("Bufferline tests:", function()
       assert.is_truthy(tabline:match(icon))
     end)
 
+    it("should allow specifying how icons are fetched", function()
+      local icon = "Q"
+      bufferline.setup({
+        options = {
+          get_element_icon = function() return icon end,
+        },
+      })
+      vim.cmd("edit test.txt")
+      local tabline = nvim_bufferline()
+      assert.truthy(tabline)
+      assert.is_truthy(tabline:match(icon))
+    end)
+
     it("should allow formatting names", function()
       bufferline.setup({
         options = {


### PR DESCRIPTION
Since there have been many requests to have icons fetch in some way that a user might prefer e.g. with defaults without defaults, by filetype, by filename, maybe eventually by different package than devicons, this PR adds a `get_icon_element` option which a user can use to decide what is return for each element which is essentially a filename, filetype, directory and path.


cc @camiloaromero23 @utilyre @CleoMenezesJr

I've closed #669 in favour of this change since that continues us down the path of option after option of `load_by_x_criteria`. This way a user can just explicitly do whatever they want.

Can you please test this PR to see if
a) It solves the original issue
b) It correctly allows you to return whatever icon you want

### TODO
- [x] Add a test case