### PR TITLE
Fix: tabs do not use seperators correctly

### DIFF
--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -29,11 +29,11 @@ local function render(tabpage, is_active, style, highlights)
   local hl = is_active and h.tab_selected.hl_group or h.tab.hl_group
   local separator_hl = is_active and h.tab_separator_selected.hl_group or h.tab_separator.hl_group
   local chars = constants.sep_chars[style] or constants.sep_chars.thin
-  local separator_component = chars[2]
-  local name = padding .. padding .. tabpage.tabnr .. padding
+  local name = padding .. tabpage.tabnr .. padding
   return {
+    { highlight = separator_hl, text = chars[2] },
     { highlight = hl, text = name, attr = { prefix = tab_click_component(tabpage.tabnr) } },
-    { highlight = separator_hl, text = separator_component },
+    { highlight = separator_hl, text = chars[1] },
   }
 end
 


### PR DESCRIPTION
This is the PR for #569.
This works perfectly for `slant` and `slope`, but I am not sure what the behavior for `thick` and `thin` is supposed to be.
If you want the behavior to be unchanged I (or you) can change it this to this, which should only change the `slant` and `slope` and custom styles:
```
  local single_char = require("bufferline.config").options.separator_style == "thick"
    or require("bufferline.config").options.separator_style == "thin"
  return {
    single_char and {} or { highlight = separator_hl, text = chars[2] },
    {
      highlight = hl,
      text = name,
      attr = { prefix = tab_click_component(tabpage.tabnr) },
    },
    { highlight = separator_hl, text = chars[single_char and 2 or 1] },

```