### PR TITLE
fix(utils): fix utils.is_list

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -242,9 +242,12 @@ function M.is_truthy(value)
     and value ~= "nil"
 end
 
+local mk_is_list = function() return vim.tbl_isarray or vim.tbl_islist end
+local _is_list = mk_is_list()
+
 -- TODO: deprecate this in nvim-0.11 or use strict lists
 --- Determine which list-check function to use
----@return function
-function M.is_list() return vim.tbl_isarray or vim.tbl_islist end
+---@return boolean
+function M.is_list(l) return _is_list(l) end
 
 return M

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -242,12 +242,8 @@ function M.is_truthy(value)
     and value ~= "nil"
 end
 
-local mk_is_list = function() return vim.tbl_isarray or vim.tbl_islist end
-local _is_list = mk_is_list()
-
 -- TODO: deprecate this in nvim-0.11 or use strict lists
 --- Determine which list-check function to use
----@return boolean
-function M.is_list(l) return _is_list(l) end
+M.is_list = vim.tbl_isarray or vim.tbl_islist
 
 return M


### PR DESCRIPTION
https://github.com/akinsho/bufferline.nvim/pull/726 Introduced a bug because `utils.is_list` need to be executed in order to return a function that will return a boolean if the object is a list. This broke the tests, now it properly returns a `boolean`.

I ran the tests with the following command I got from the ci workflow yaml.
```sh
nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua', sequential = true}"
```

I also ran the formatter with:
```sh
stylua --config-path=stylua.toml lua/
```