### PR TITLE
Use new isarray function

### DIFF
--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -94,7 +94,7 @@ end
 ---@return number[]
 local function is_valid_layout(windows)
   local win_type, win_id = windows[1], windows[2]
-  if vim.tbl_islist(win_id) and win_type == t.COLUMN then win_id = win_id[1][2] end
+  if vim.tbl_isarray(win_id) and win_type == t.COLUMN then win_id = win_id[1][2] end
   return supported_win_types[win_type] and type(win_id) == "number", win_id
 end
 

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -129,7 +129,7 @@ end
 ---@param segments Segment[]
 ---@return integer
 local function get_component_size(segments)
-  assert(vim.tbl_islist(segments), "Segments must be a list")
+  assert(vim.tbl_isarray(segments), "Segments must be a list")
   local sum = 0
   for _, s in pairs(segments) do
     if has_text(s) then sum = sum + strwidth(tostring(s.text)) end

--- a/tests/sorters_spec.lua
+++ b/tests/sorters_spec.lua
@@ -17,14 +17,14 @@ describe("Sorters - ", function()
     bufferline.setup({ options = { sort_by = "none" } })
     local bufs = { { id = 12 }, { id = 2 }, { id = 3 }, { id = 8 } }
     local list = sorters.sort(bufs)
-    assert.is_true(vim.tbl_islist(list))
+    assert.is_true(vim.tbl_isarray(list))
   end)
 
   it("should return an unsorted list sort is none", function()
     bufferline.setup({ options = { sort_by = "none" } })
     local bufs = { { id = 12 }, { id = 2 }, { id = 3 }, { id = 8 } }
     local list = sorters.sort(bufs)
-    assert.is_true(vim.tbl_islist(list))
+    assert.is_true(vim.tbl_isarray(list))
     local ids = vim.tbl_map(function(buf) return buf.id end, list)
     assert.same(ids, { 12, 2, 3, 8 })
   end)


### PR DESCRIPTION
On dev neovim branch there is a change (https://github.com/neovim/neovim/commit/7caf0eaf) that modifies the islist function. Modifying bufferline ui to use isarray function (to keep the same functionality)