### PR TITLE
feat(diag): sane fallback to underline color

### DIFF
--- a/lua/bufferline/colors.lua
+++ b/lua/bufferline/colors.lua
@@ -48,7 +48,7 @@ end
 local new_hl_api = api.nvim_get_hl ~= nil
 local get_hl = function(name, use_cterm)
   if new_hl_api then
-    local hl = api.nvim_get_hl(0, { name = name })
+    local hl = api.nvim_get_hl(0, { name = name, link = false })
     if use_cterm then
       hl.fg, hl.bg = hl.ctermfg, hl.ctermbg
     end

--- a/lua/bufferline/colors.lua
+++ b/lua/bufferline/colors.lua
@@ -58,6 +58,14 @@ local get_hl = function(name, use_cterm)
   return api.nvim_get_hl_by_name(name, not use_cterm)
 end
 
+-- Map of nvim_get_hl() highlight attributes (new API) to
+-- nvim_get_hl_by_name() highlight attributes (old API).
+local hl_color_attrs = {
+  fg = "foreground",
+  bg = "background",
+  sp = "special",
+}
+
 -- parses the gui hex color code (or cterm color number) from the given hl_name
 --   color number (0-255) is returned if cterm is set to true in opts
 --   if unable to parse, uses the fallback value
@@ -68,11 +76,13 @@ function M.get_color(opts)
     opts.name, opts.attribute, opts.fallback, opts.not_match, opts.cterm
   -- translate from internal part to hl part
   assert(
-    attribute == "fg" or attribute == "bg",
-    fmt('attribute for %s should be one of "fg" or "bg", "%s" was passed in ', name, attribute)
+    hl_color_attrs[attribute],
+    fmt('unsupported attribute %s for %s, should be one of %s', attribute, name, table.concat(vim.tbl_keys(hl_color_attrs), ", "))
   )
   -- TODO: remove when 0.9 is stable
-  if not new_hl_api then attribute = attribute == "fg" and "foreground" or "background" end
+  if not new_hl_api then
+    attribute = hl_color_attrs[attribute]
+  end
 
   -- try and get hl from name
   local success, hl = pcall(get_hl, name, cterm)

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -187,27 +187,55 @@ local function derive_colors(preset)
   local string_fg = hex({ name = "String", attribute = "fg" })
 
   local error_fg = hex({
-    name = "DiagnosticError",
+    name = "DiagnosticError", -- diagnostic with text highlight
     attribute = "fg",
-    fallback = { name = "Error", attribute = "fg" },
+    fallback = {
+      name = "DiagnosticError", -- diagnostic with underline highlight
+      attribute = "sp",
+      fallback = {
+        name = "Error",
+        attribute = "fg",
+      },
+    },
   })
 
   local warning_fg = hex({
     name = "DiagnosticWarn",
     attribute = "fg",
-    fallback = { name = "WarningMsg", attribute = "fg" },
+    fallback = {
+      name = "DiagnosticWarn",
+      attribute = "sp",
+      fallback = {
+        name = "WarningMsg",
+        attribute = "fg",
+      },
+    },
   })
 
   local info_fg = hex({
     name = "DiagnosticInfo",
     attribute = "fg",
-    fallback = { name = "Normal", attribute = "fg" },
+    fallback = {
+      name = "DiagnosticInfo",
+      attribute = "sp",
+      fallback = {
+        name = "Normal",
+        attribute = "fg",
+      },
+    },
   })
 
   local hint_fg = hex({
     name = "DiagnosticHint",
     attribute = "fg",
-    fallback = { name = "Directory", attribute = "fg" },
+    fallback = {
+      name = "DiagnosticHint",
+      attribute = "sp",
+      fallback = {
+        name = "Directory",
+        attribute = "fg",
+      },
+    },
   })
 
   local tabline_sel_bg = hex({


### PR DESCRIPTION
**tl;dr** To support colorschemes where LSP diagnostics are highlighted with colored underlines instead of foreground text (see screenshot below), check whether the `special` attribute exists before using the fallback group.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/3299086/189524284-fd6fb4d5-dc59-43e6-ae78-c5952eb49c47.png">

Result, here with an error diagnostic:

![image](https://user-images.githubusercontent.com/3299086/233830284-cdcc84a8-ec37-4d83-ab72-098d454b7588.png)

---

My main motivation is to allow a sensible fallback to the <ins>underline</ins> color in case any of the `DiagnosticError`, `DiagnosticWarn`, `DiagnosticHint` or `DiagnosticInfo` highlight groups do not have a foreground color set.

In many IDEs, it is a [common practice](https://user-images.githubusercontent.com/7727148/38758132-7284e58a-3f24-11e8-8e39-627e6916e9ec.PNG) to highlight diagnostics by underlining the context, instead of changing its foreground color. Due to Vim's legacy of supporting terminals without capabilities such as _italics_, **bold** or <ins>underline</ins>, this has never become a widespread pattern in our favourite text editor. Nevertheless, some (fairly popular) color schemes — such as [everforest](https://github.com/sainnhe/everforest), [gruvbox-material](https://github.com/sainnhe/gruvbox-material) or [sonokai](https://github.com/sainnhe/sonokai) — do apply underline styles to these highlight groups, and right now bufferline can't handle this practice very well (none of the colors below match the colorscheme's):

_error_
![error](https://user-images.githubusercontent.com/3299086/232437266-785bb34e-e05d-491a-b0b1-aa7aeae8aa0f.png "error")

_warn_
![warn](https://user-images.githubusercontent.com/3299086/232437265-f84871b4-12ef-4e63-84ec-26409d48129b.png "warn")

_hint_
![hint](https://user-images.githubusercontent.com/3299086/232437259-1d74b54e-c5cb-4f4e-8e51-6a4fd36f275d.png "hint")

_info_
![info](https://user-images.githubusercontent.com/3299086/232437269-d114e501-3d30-429f-9698-5911f8cf1ae5.png "info")


I believe that it is sensible and unintrusive to check for the existence of the `special` attribute during the initialization of `error_fg`, `warning_fg`, etc. before moving on to the final fallback.

Fixes https://github.com/sainnhe/everforest/issues/121