### PR TITLE
docs(help): update buffer_close_icon

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -79,7 +79,7 @@ The available configuration are:
                 icon = '▎', -- this should be omitted if indicator style is not 'icon'
                 style = 'icon' | 'underline' | 'none',
             },
-            buffer_close_icon = '',
+            buffer_close_icon = '󰅖',
             modified_icon = '●',
             close_icon = '',
             left_trunc_marker = '',


### PR DESCRIPTION
In 83b4d0b, the default `buffer_close_icon` was updated to reflect the breaking changes in Nerd Fonts, however the documentation was not updated to use this new default in its example config. This PR updates that to make them consistent.