### PR TITLE
fix(ui): Exclude hidden buffers from the list

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -132,7 +132,14 @@ function M.is_valid(buf_num)
 end
 
 ---@return integer
-function M.get_buf_count() return #fn.getbufinfo({ buflisted = 1 }) end
+function M.get_buf_count()
+  local buffers = vim.tbl_filter(
+    function(buf) return vim.fn.getbufvar(buf.bufnr, "&bufhidden") ~= "hide" end,
+    fn.getbufinfo({ buflisted = 1 })
+  )
+
+  return #buffers
+end
 
 ---@return integer[]
 function M.get_valid_buffers() return vim.tbl_filter(M.is_valid, vim.api.nvim_list_bufs()) end


### PR DESCRIPTION
When using the `always_show_bufferline` in conjunction with `null-ls` for formatting, the plugin will break the cursor location when formatting. This happens due to the fact that null-ls creates a temporary scratch buffer, runs the formatter, then destroys the temp buffer. In the middle of this, bufferline will see multiple buffers and for a moment attempt to render the bufferline, then hide it again. This seems to be breaking cursor position.

The fix I applied to this was to exclude hidden buffers from the total buffer count. I'm curious your thoughts on the implementation and if there would be any issues from this change.