### PR TITLE
docs: fix commas in highlights examples

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -800,15 +800,15 @@ NOTE: you can specify colors the same way you specify colors for
             },
             background = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             tab = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             tab_selected = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             tab_separator = {
               fg = '<colour-value-here>',
@@ -822,23 +822,23 @@ NOTE: you can specify colors the same way you specify colors for
             },
             tab_close = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             close_button = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             close_button_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             close_button_selected = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             buffer_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             buffer_selected = {
                 fg = '<colour-value-here>',
@@ -877,91 +877,91 @@ NOTE: you can specify colors the same way you specify colors for
             hint = {
                 fg = '<colour-value-here>',
                 sp = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             hint_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             hint_selected = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
                 bold = true,
                 italic = true,
             },
             hint_diagnostic = {
                 fg = '<colour-value-here>',
                 sp = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             hint_diagnostic_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             hint_diagnostic_selected = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
                 bold = true,
                 italic = true,
             },
             info = {
                 fg = '<colour-value-here>',
                 sp = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             info_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             info_selected = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
                 bold = true,
                 italic = true,
             },
             info_diagnostic = {
                 fg = '<colour-value-here>',
                 sp = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             info_diagnostic_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             info_diagnostic_selected = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
                 bold = true,
                 italic = true,
             },
             warning = {
                 fg = '<colour-value-here>',
                 sp = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             warning_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             warning_selected = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
                 bold = true,
                 italic = true,
             },
             warning_diagnostic = {
                 fg = '<colour-value-here>',
                 sp = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             warning_diagnostic_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             warning_diagnostic_selected = {
                 fg = '<colour-value-here>',
@@ -973,81 +973,81 @@ NOTE: you can specify colors the same way you specify colors for
             error = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
             },
             error_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             error_selected = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
                 bold = true,
                 italic = true,
             },
             error_diagnostic = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
             },
             error_diagnostic_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             error_diagnostic_selected = {
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
-                sp = '<colour-value-here>'
+                sp = '<colour-value-here>',
                 bold = true,
                 italic = true,
             },
             modified = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             modified_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             modified_selected = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             duplicate_selected = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
                 italic = true,
             },
             duplicate_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
-                italic = true
+                bg = '<colour-value-here>',
+                italic = true,
             },
             duplicate = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
-                italic = true
+                bg = '<colour-value-here>',
+                italic = true,
             },
             separator_selected = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             separator_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             separator = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             indicator_visible = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             indicator_selected = {
                 fg = '<colour-value-here>',
-                bg = '<colour-value-here>'
+                bg = '<colour-value-here>',
             },
             pick_selected = {
                 fg = '<colour-value-here>',
@@ -1082,8 +1082,8 @@ numbers](https://www.ditig.com/256-colors-cheat-sheet).
 for example: >lua
     highlights = {
         fill = {
-            ctermbg = 7
-            ctermfg = 0
+            ctermbg = 7,
+            ctermfg = 0,
         }
     }
 


### PR DESCRIPTION
Add commas in some examples so that users can copy them directly without having errors like

```lua
fg = '<colour-value-here>',
bg = '<colour-value-here>',
sp = '<colour-value-here>'  -- missing a comma here
bold = true,
italic = true,
```