### PR TITLE
feat(ui): trunc marker highlights

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -1072,6 +1072,10 @@ NOTE: you can specify colors the same way you specify colors for
                 fg = '<colour-value-here>',
                 bg = '<colour-value-here>',
             },
+            trunc_marker = {
+                fg = '<colour-value-here>',
+                bg = '<colour-value-here>',
+            }
         };
     })
 <

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -268,7 +268,14 @@ local function derive_colors(preset)
 
   local underline_sp = has_underline_indicator and tabline_sel_bg or nil
 
+  local trunc_marker_fg = comment_fg
+  local trunc_marker_bg = separator_background_color
+
   return {
+    trunc_marker = {
+      fg = trunc_marker_fg,
+      bg = trunc_marker_bg
+    },
     fill = {
       fg = comment_fg,
       bg = separator_background_color,

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -680,9 +680,9 @@ function M.tabline(items, tab_indicators)
     right_element_size = right_element_size,
   })
 
-  local fill = hl.fill.hl_group
-  local left_marker = get_trunc_marker(left_trunc_icon, fill, fill, marker.left_count)
-  local right_marker = get_trunc_marker(right_trunc_icon, fill, fill, marker.right_count)
+  local marker_hl = hl.trunc_marker.hl_group
+  local left_marker = get_trunc_marker(left_trunc_icon, marker_hl, marker_hl, marker.left_count)
+  local right_marker = get_trunc_marker(right_trunc_icon, marker_hl, marker_hl, marker.right_count)
 
   local core = join(
     utils.merge_lists(


### PR DESCRIPTION
I added a new highlight for the trunc marker, because it was using the `BufferLineFill` hl.
I also updated the docs.