### PR TITLE
Fix highlighting for tab separators

### DIFF
--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -559,7 +559,7 @@ local function derive_colors(preset)
     },
     tab_separator_selected = {
       fg = separator_background_color,
-      bg = visible_bg,
+      bg = normal_bg,
       sp = underline_sp,
       underline = has_underline_indicator,
     },


### PR DESCRIPTION
This PR fixes a bug introduced in [this commit](https://github.com/akinsho/bufferline.nvim/commit/13cb114e91c17238aaa271746aaeb8e967f350a2) in `lua/bufferline/config.lua` at line 563: `normal_bg` was replaced with `visible_bg` for `tab_separator_selected` background color which is inconsistent with `separator_selected` background color and produces this problem: 
![problem](https://github.com/akinsho/bufferline.nvim/assets/87815870/34e8d61d-08ca-4d8d-a32a-323d52cc5e6e)
