### PR TITLE
Workaround to fix `list` is `nil` in `commands.lua`

### DIFF
--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -129,9 +129,11 @@ end
 function M.get_current_element_index(current_state, opts)
   opts = opts or { include_hidden = false }
   local list = opts.include_hidden and current_state.__components or current_state.components
-  for index, item in ipairs(list) do
-    local element = item:as_element()
-    if element and element.id == get_current_element() then return index, element end
+  if (list ~= nil) then
+    for index, item in ipairs(list) do
+      local element = item:as_element()
+      if element and element.id == get_current_element() then return index, element end
+    end
   end
 end
 


### PR DESCRIPTION
Sometimes the `list` variable is `nil`, and I am not completely sure why this happens. 🌚 

However, I have implemented a simple workaround to fix this issue.

Original error message:
```
Error detected while processing BufEnter Autocommands for "*":
Error executing lua callback: ...re/nvim/lazy/bufferline.nvim/lua/bufferline/commands.lua:132: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
        [C]: in function 'ipairs'
        ...re/nvim/lazy/bufferline.nvim/lua/bufferline/commands.lua:132: in function 'get_current_element_index'
        ...hare/nvim/lazy/bufferline.nvim/lua/bufferline/groups.lua:491: in function 'handle_group_enter'
        ...local/share/nvim/lazy/bufferline.nvim/lua/bufferline.lua:139: in function <...local/share/nvim/lazy/bufferline.nvim/lua/bufferline.lua:139
```