### PR TITLE
feat: Support `name_formatter` for unnamed buffers

### DIFF
--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -176,10 +176,12 @@ function Buffer:new(buf)
   if buf.path and #buf.path > 0 then
     name = fn.fnamemodify(buf.path, ":t")
     name = is_directory and name .. "/" or name
-    if buf.name_formatter and type(buf.name_formatter) == "function" then
-      name = buf.name_formatter({ name = name, path = buf.path, bufnr = buf.id }) or name
-    end
   end
+
+  if buf.name_formatter and type(buf.name_formatter) == "function" then
+    name = buf.name_formatter({ name = name, path = buf.path, bufnr = buf.id }) or name
+  end
+
   buf.name = name
 
   setmetatable(buf, self)


### PR DESCRIPTION
This adds a new config option `unnamed_title` to support changing the name of unnamed buffers from `[No Name]` to anything the user wants (e.g. `Untitled`).