### PR TITLE
fix: remove `missing required fields` diagnostic from config

### DIFF
--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -4,15 +4,15 @@
 ---@field logging boolean
 
 ---@class bufferline.GroupOptions
----@field toggle_hidden_on_enter boolean re-open hidden groups on bufenter
+---@field toggle_hidden_on_enter? boolean re-open hidden groups on bufenter
 
 ---@class bufferline.GroupOpts
----@field options bufferline.GroupOptions
+---@field options? bufferline.GroupOptions
 ---@field items bufferline.Group[]
 
 ---@class bufferline.Indicator
----@field style "underline" | "icon" | "none"
----@field icon string?
+---@field style? "underline" | "icon" | "none"
+---@field icon? string?
 
 ---@alias bufferline.Mode 'tabs' | 'buffers'
 
@@ -22,70 +22,70 @@
 ---@alias bufferline.IconFetcherOpts {directory: boolean, path: string, extension: string, filetype: string?}
 
 ---@class bufferline.Options
----@field public mode bufferline.Mode
----@field public style_preset bufferline.StylePreset | bufferline.StylePreset[]
----@field public view string
----@field public debug bufferline.DebugOpts
----@field public numbers string | fun(ordinal: number, id: number, lower: number_helper, raise: number_helper): string
----@field public buffer_close_icon string
----@field public modified_icon string
----@field public close_icon string
----@field public close_command string | function
----@field public custom_filter fun(buf: number, bufnums: number[]): boolean
----@field public left_mouse_command string | function
----@field public right_mouse_command string | function
----@field public middle_mouse_command (string | function)?
----@field public indicator bufferline.Indicator
----@field public left_trunc_marker string
----@field public right_trunc_marker string
----@field public separator_style string | {[1]: string, [2]: string}
----@field public name_formatter (fun(path: string):string)?
----@field public tab_size number
----@field public truncate_names boolean
----@field public max_name_length number
----@field public color_icons boolean
----@field public show_buffer_icons boolean
----@field public show_buffer_close_icons boolean
----@field public show_buffer_default_icon boolean
----@field public get_element_icon fun(opts: bufferline.IconFetcherOpts): string?, string?
----@field public show_close_icon boolean
----@field public show_tab_indicators boolean
----@field public show_duplicate_prefix boolean
----@field public enforce_regular_tabs boolean
----@field public always_show_bufferline boolean
----@field public persist_buffer_sort boolean
----@field public move_wraps_at_ends boolean
----@field public max_prefix_length number
----@field public sort_by string
----@field public diagnostics boolean | 'nvim_lsp' | 'coc'
----@field public diagnostics_indicator bufferline.DiagnosticIndicator
----@field public diagnostics_update_in_insert boolean
----@field public offsets table[]
----@field public groups bufferline.GroupOpts
----@field public themable boolean
----@field public hover bufferline.HoverOptions
+---@field public mode? bufferline.Mode
+---@field public style_preset? bufferline.StylePreset | bufferline.StylePreset[]
+---@field public view? string
+---@field public debug? bufferline.DebugOpts
+---@field public numbers? string | fun(ordinal: number, id: number, lower: number_helper, raise: number_helper): string
+---@field public buffer_close_icon? string
+---@field public modified_icon? string
+---@field public close_icon? string
+---@field public close_command? string | function
+---@field public custom_filter? fun(buf: number, bufnums: number[]): boolean
+---@field public left_mouse_command? string | function
+---@field public right_mouse_command? string | function
+---@field public middle_mouse_command? (string | function)?
+---@field public indicator? bufferline.Indicator
+---@field public left_trunc_marker? string
+---@field public right_trunc_marker? string
+---@field public separator_style? string | {[1]: string, [2]: string}
+---@field public name_formatter? (fun(path: string):string)?
+---@field public tab_size? number
+---@field public truncate_names? boolean
+---@field public max_name_length? number
+---@field public color_icons? boolean
+---@field public show_buffer_icons? boolean
+---@field public show_buffer_close_icons? boolean
+---@field public show_buffer_default_icon? boolean
+---@field public get_element_icon? fun(opts: bufferline.IconFetcherOpts): string?, string?
+---@field public show_close_icon? boolean
+---@field public show_tab_indicators? boolean
+---@field public show_duplicate_prefix? boolean
+---@field public enforce_regular_tabs? boolean
+---@field public always_show_bufferline? boolean
+---@field public persist_buffer_sort? boolean
+---@field public move_wraps_at_ends? boolean
+---@field public max_prefix_length? number
+---@field public sort_by? string
+---@field public diagnostics? boolean | 'nvim_lsp' | 'coc'
+---@field public diagnostics_indicator? bufferline.DiagnosticIndicator
+---@field public diagnostics_update_in_insert? boolean
+---@field public offsets? table[]
+---@field public groups? bufferline.GroupOpts
+---@field public themable? boolean
+---@field public hover? bufferline.HoverOptions
 
 ---@class bufferline.HLGroup
----@field fg string
----@field bg string
----@field sp string
----@field special string
----@field bold boolean
----@field italic boolean
----@field underline boolean
----@field undercurl boolean
----@field hl_group string
----@field hl_name string
+---@field fg? string
+---@field bg? string
+---@field sp? string
+---@field special? string
+---@field bold? boolean
+---@field italic? boolean
+---@field underline? boolean
+---@field undercurl? boolean
+---@field hl_group? string
+---@field hl_name? string
 
 ---@alias bufferline.Highlights table<string, bufferline.HLGroup>
 
 ---@class bufferline.UserConfig
----@field public options bufferline.Options
----@field public highlights bufferline.Highlights | fun(BufferlineHighlights): bufferline.Highlights
+---@field public options? bufferline.Options
+---@field public highlights? bufferline.Highlights | fun(BufferlineHighlights): bufferline.Highlights
 
 ---@class bufferline.Config
----@field public options bufferline.Options
----@field public highlights bufferline.Highlights
+---@field public options? bufferline.Options
+---@field public highlights? bufferline.Highlights
 ---@field user bufferline.UserConfig original copy of user preferences
 ---@field merge fun(self: bufferline.Config, defaults: bufferline.Config): bufferline.Config
 ---@field validate fun(self: bufferline.Config, defaults: bufferline.Config, resolved: bufferline.Highlights): nil
@@ -96,9 +96,9 @@
 --- @alias bufferline.Duplicate "path" | "element" | nil
 
 ---@class bufferline.Component
----@field name string?
+---@field name? string
 ---@field id integer
----@field path string?
+---@field path? string
 ---@field length integer
 ---@field component fun(BufferlineState): bufferline.Segment[]
 ---@field hidden boolean
@@ -175,16 +175,16 @@
 ---@alias GroupSeparators table<string, GroupSeparator>
 
 ---@class bufferline.Group
----@field public id string used for identifying the group in the tabline
----@field public name string 'formatted name of the group'
----@field public display_name string original name including special characters
----@field public matcher fun(b: bufferline.Buffer): boolean?
----@field public separator GroupSeparators
----@field public priority number
----@field public highlight table<string, string>
----@field public icon string
----@field public hidden boolean
----@field public with fun(Group, Group): bufferline.Group
+---@field public id? string used for identifying the group in the tabline
+---@field public name? string 'formatted name of the group'
+---@field public display_name? string original name including special characters
+---@field public matcher? fun(b: bufferline.Buffer): boolean?
+---@field public separator? GroupSeparators
+---@field public priority? number
+---@field public highlight? table<string, string>
+---@field public icon? string
+---@field public hidden? boolean
+---@field public with? fun(Group, Group): bufferline.Group
 ---@field auto_close boolean when leaving the group automatically close it
 
 ---@class bufferline.RenderContext


### PR DESCRIPTION
As discussed in the mentioned issue, it appears that some changes to lua_ls mean that not including non-optional fields in a config table throws a diagnostic warning, as shown in the screenshot. As the issue mentions, it's possible to disable this behavior globally or with a `---@diagnostic disable-next-line missing-fields` comment before the table, but I think it would still be greatly desirable to have bufferline not throw warnings for non-mandatory fields by default.

I've tried my best to only make the non-mandatory fields optional, but I probably over or under-modified the types, so please feel free to add/remove `?`s around the types file.

https://github.com/LuaLS/lua-language-server/issues/2214#issuecomment-1686426027
<img width="1445" alt="Screenshot 2023-09-07 at 11 48 57 AM" src="https://github.com/akinsho/bufferline.nvim/assets/92702993/6b546d12-08b5-485f-8989-460cd0af40ee">
