### PR TITLE
fix: display overriden devicons

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -202,7 +202,7 @@ function M.get_icon(opts)
   end
   if type == "terminal" then return webdev_icons.get_icon(type) end
 
-  local icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), opts.extension, {
+  local icon, hl = webdev_icons.get_icon(fn.fnamemodify(opts.path, ":t"), nil, {
     default = true,
   })
 


### PR DESCRIPTION
pretty much a fix for #191

normally  `bufferline` retrieves the file extension using `vim.fn.fnamemodify` with the `:e` option, but that doesn't account for extensions with multiple dots, by passing nil instead of that extension, the inner recursive mechanism of `nvim-web-devicons` is utilized to get the longest matching extension from the filename

before:
![before](https://github.com/akinsho/bufferline.nvim/assets/145394295/47b4d38c-efc4-4eea-83dc-30051c44bad3)

after:
![after](https://github.com/akinsho/bufferline.nvim/assets/145394295/3fdb072d-9fe9-4220-9c47-9dbf95b198f3)
