### PR TITLE
fix: UI error when UI's `diagnostic.text` is `nil`

### DIFF
--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -497,7 +497,7 @@ function M.element(current_state, element)
     set_id(name, components.id.name),
     spacing({ when = name, highlight = curr_hl.buffer }),
     set_id(diagnostic, components.id.diagnostics),
-    spacing({ when = diagnostic and #diagnostic.text > 0 }),
+    spacing({ when = diagnostic and diagnostic.text and #diagnostic.text > 0 }),
     right_space,
     suffix,
     spacing({ when = suffix }),


### PR DESCRIPTION
I can't create reproducible example, but this problem periodically happens to me personally. 

After some action (deleting line most frequent) raises an error after which tabs line becomes as neovim default and this plugin needs to be re-initilized.

It also happens if I use `lazy.nvim` as plugin manager and running `Sync` command.