### PR TITLE
Fix potential nil access

### DIFF
--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -120,7 +120,7 @@ function M.go_to(num, absolute)
   local element = list[num]
   if num == -1 or not element then element = list[#list] end
 
-  if element ~= nil then
+  if element then
     open_element(element.id)
   end
 end

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -119,7 +119,10 @@ function M.go_to(num, absolute)
   local list = absolute and state.components or state.visible_components
   local element = list[num]
   if num == -1 or not element then element = list[#list] end
-  open_element(element.id)
+
+  if element ~= nil then
+    open_element(element.id)
+  end
 end
 
 ---@param current_state bufferline.State


### PR DESCRIPTION
If one uses this method mapped to keys and accidentally hit a number with a non-existing buffer, `element` can be nil:

```
E5108: Error executing lua: ...re/nvim/lazy/bufferline.nvim/lua/bufferline/commands.lua:122: attempt to index local 'element' (a nil value)
stack traceback:
        ...re/nvim/lazy/bufferline.nvim/lua/bufferline/commands.lua:122: in function 'go_to'
```