### PR TITLE
use link if specified in custom areas

### DIFF
--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -11,9 +11,12 @@ local fmt = string.format
 ---generate a custom highlight group
 ---@param index integer
 ---@param side string
----@param section {fg: string, bg: string, text: string}
+---@param section {fg: string, bg: string, text: string, link: string}
 ---@param bg string?
 local function create_hl(index, side, section, bg)
+  if section.link then
+    return highlights.hl(section.link)
+  end
   local name = fmt("BufferLine%sCustomAreaText%d", side:gsub("^%l", string.upper), index)
   section.bg = section.bg or bg
   section.default = true -- We need to be able to constantly override these highlights so they should always be default


### PR DESCRIPTION
fix #838 

If use specified a highlight group via link, use it instead of creating a new group