### PR TITLE
fix a typo in rename_tab

### DIFF
--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -36,7 +36,7 @@ end
 
 function M.rename_tab(tabnr, name)
   if tabnr == 0 then tabnr = vim.fn.tabpagenr() end
-  if name == "" then name = string(tabnr) end
+  if name == "" then name = tostring(tabnr) end
   api.nvim_tabpage_set_var(tabnr, "name", name)
   ui.refresh()
 end


### PR DESCRIPTION
`string` cannot be called directly:
```
attempt to call a table value (global 'string')
```
To convert a number to string in Lua, we need to call `tostring(num)` instead.