### PR TITLE
feat: add `auto_toggle_bufferline` option

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -157,6 +157,7 @@ The available configuration are:
             separator_style = "slant" | "slope" | "thick" | "thin" | { 'any', 'any' },
             enforce_regular_tabs = false | true,
             always_show_bufferline = true | false,
+            auto_toggle_bufferline = true | false,
             hover = {
                 enabled = true,
                 delay = 200,

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -88,6 +88,7 @@ end
 
 --- If the item count has changed and the next tabline status is different then update it
 local function toggle_bufferline()
+  if not config.options.auto_toggle_bufferline then return end
   local item_count = config:is_tabline() and utils.get_tab_count() or utils.get_buf_count()
   local status = (config.options.always_show_bufferline or item_count > 1) and 2 or 0
   if vim.o.showtabline ~= status then vim.o.showtabline = status end

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -648,6 +648,7 @@ local function get_defaults()
     show_duplicate_prefix = true,
     enforce_regular_tabs = false,
     always_show_bufferline = true,
+    auto_toggle_bufferline = true,
     persist_buffer_sort = true,
     move_wraps_at_ends = false,
     max_prefix_length = 15,

--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -53,6 +53,7 @@
 ---@field public show_duplicate_prefix? boolean
 ---@field public enforce_regular_tabs? boolean
 ---@field public always_show_bufferline? boolean
+---@field public auto_toggle_bufferline? boolean
 ---@field public persist_buffer_sort? boolean
 ---@field public move_wraps_at_ends? boolean
 ---@field public max_prefix_length? number


### PR DESCRIPTION
Currently, there are no commands for enabling, disabling, or toggling the bufferline. The current way to control the visibility of the tabline (as mentioned in #651 and #829) is to set the `showtabline` option. However, this does not reliably control the visibility of the tabline because bufferline.nvim overwrites this option. 

This PR adds a configuration option called `auto_toggle_bufferline`. When set to `false`, bufferline.nvim will not overwrite the `showtabline` option. This more closely aligns with the default behaviour of the built-in Vim tabline. That is, setting `showtabline` to `0` will hide the tabline, and it will not be reappear unless this option is modified manually. 

To maintain backwards compatibility and avoid breaking existing configurations, `auto_toggle_bufferline` is set to `true` by default. This means that the default behavior of bufferline.nvim will remain unchanged. However, this allows users who desire more control can set `auto_toggle_bufferline` to `false` in their configuration to disable the automatic toggling and instead rely on the `showtabline` option.

Related issue: #874.