### PR TITLE
fix(tabpages): renaming bug on reopened tab

### DIFF
--- a/lua/bufferline/tabpages.lua
+++ b/lua/bufferline/tabpages.lua
@@ -35,9 +35,8 @@ local function render(tabpage, is_active, style, highlights)
 end
 
 function M.rename_tab(tabnr, name)
-  if tabnr == 0 then tabnr = vim.fn.tabpagenr() end
   if name == "" then name = tostring(tabnr) end
-  api.nvim_tabpage_set_var(tabnr, "name", name)
+  api.nvim_tabpage_set_var(0, "name", name)
   ui.refresh()
 end
 


### PR DESCRIPTION
vim.fn.tabpagenr gets the tab number but api.nvim_tabpage_set_var expects tab id, meaning the tab rename would fail if a tab was closed and reopened. This change passes 0 into api.nvim_tabpage_set_var which will use the current focused tab without needing to retrieve the id.

Before this change:

https://github.com/akinsho/bufferline.nvim/assets/159239255/d219e828-6997-4bb0-8fda-07a41c58e085



After this change:

https://github.com/akinsho/bufferline.nvim/assets/159239255/0bf298bd-d6d2-438c-9b5f-c3254397e1b0


PS: Thank you for making bufferline!
