### PR TITLE
fix(commands.lua): fix function close_others

### DIFF
--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -248,8 +248,13 @@ function M.close_others()
   local index = M.get_current_element_index(state)
   if not index then return end
 
-  for i, item in ipairs(state.components) do
-    if i ~= index then delete_element(item.id) end
+  local id = 1
+  for i in ipairs(state.components) do
+    if i ~= index then
+      delete_element(id)
+    else
+      id = 2
+    end
   end
   ui.refresh()
 end


### PR DESCRIPTION
![image](https://github.com/akinsho/bufferline.nvim/assets/15901048/0678bb7e-fca6-43a0-8081-d907d6949e27)
I encountered an error because item.id in state.components is no longer suitable for tabclose to use. I changed the code to be able to close the tabs before and after the current tab. I use Windows OS.