### PR TITLE
feat: add get_index() to get a buffer's index from its buffer id

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -29,6 +29,7 @@ local M = {
   sort_by = commands.sort_by,
   pick = commands.pick,
   get_elements = commands.get_elements,
+  get_index = commands.get_index,
   close_with_pick = commands.close_with_pick,
   close_in_direction = commands.close_in_direction,
   rename_tab = commands.rename_tab,

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -276,6 +276,17 @@ function M.rename_tab(args)
   tabpage.rename_tab(tabnr, name)
 end
 
+--- Gets the index for a given buffer id
+--- @param id number the vim assigned buffer id
+--- @return bufferline.TabElement?
+function M.get_index(id)
+  local list = current_state.components
+  for index, item in ipairs(list) do
+    local element = item:as_element()
+    if element and element.id == id then return index, element end
+  end
+end
+
 _G.___bufferline_private.handle_close = handle_close
 _G.___bufferline_private.handle_click = handle_click
 _G.___bufferline_private.handle_group_click = handle_group_click

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -280,7 +280,7 @@ end
 --- @param id number the vim assigned buffer id
 --- @return bufferline.TabElement?
 function M.get_index(id)
-  local list = current_state.components
+  local list = state.components
   for index, item in ipairs(list) do
     local element = item:as_element()
     if element and element.id == id then return index, element end


### PR DESCRIPTION
Closes #861 and associated request by allowing users to get the index of a given buffer from its buffer id.

This method of solving the issue was taken from #881