### PR TITLE
fix(utils): improve path separator detection on Windows

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -121,7 +121,7 @@ function M.tbl_reverse_lookup(tbl)
   return ret
 end
 
-M.path_sep = vim.startswith(vim.loop.os_uname().sysname, "Windows") and "\\" or "/"
+M.path_sep = vim.fn.has("win32") == 1 and "\\" or "/"
 
 -- The provided api nvim_is_buf_loaded filters out all hidden buffers
 --- @param buf_num integer


### PR DESCRIPTION
If you use neovim binary from [MSYS2 packages](https://packages.msys2.org/base/mingw-w64-neovim), the `vim.loop.os_uname()` output will be like this:
```
{
  machine = "x86_64",
  release = "10.0.22631",
  sysname = "MINGW32_NT-10.0",
  version = "Windows 11 Pro"
}
```
`sysname` will not start with “Windows”, even if you're on Windows. This will break the duplicate prefix feature.

This PR uses a common method to detect Windows.