### PR TITLE
fix: change from vim.tbl_isarray & vim.tbl_islist to vim.isarray & vi…

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -252,6 +252,6 @@ end
 
 -- TODO: deprecate this in nvim-0.11 or use strict lists
 --- Determine which list-check function to use
-M.is_list = vim.tbl_isarray or vim.tbl_islist
+M.is_list = vim.isarray or vim.islist
 
 return M


### PR DESCRIPTION
Neovim build `NVIM v0.10.0-dev-2973+gf694d020c5`
has errors shown below

![image](https://github.com/akinsho/bufferline.nvim/assets/42316655/7a16f1f1-28ad-46ea-a9b7-7bd18d3702b1)

updated the functions like so