### PR TITLE
fix(util): flip logic to determine version specific utils.is_list

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -254,9 +254,9 @@ end
 --- Determine which list-check function to use
 
 if vim.fn.has("nvim-0.10") == 1 then
-  M.is_list = vim.isarray or vim.islist
-else
   M.is_list = vim.tbl_isarray or vim.tbl_islist
+else
+  M.is_list = vim.isarray or vim.islist
 end
 
 return M


### PR DESCRIPTION
### Summary

PR #892 completely broke my setup. After some investigation, flipping the logic for choosing the correct `is_list` util function seems to fix it for me. I __can't__ confirm whether this is true for neovim versions < v0.10.0.

### Misc

Neovim version:

```text
NVIM v0.10.0-dev-2671+gdc110cba3c
Build type: RelWithDebInfo
LuaJIT 2.1.1710088188
Run "nvim -V1 -v" for more info
```

### Edit: Obsolete; read below.