### PR TITLE
Add annotation to ignore deprecated method

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -256,6 +256,7 @@ end
 if vim.fn.has("nvim-0.10") == 1 then
   M.is_list = vim.isarray or vim.islist
 else
+---@diagnostic disable-next-line: deprecated
   M.is_list = vim.tbl_isarray or vim.tbl_islist
 end
 


### PR DESCRIPTION
- this is causing errors on nvim-0.10


![image](https://github.com/akinsho/bufferline.nvim/assets/20018825/408ac8af-b491-4eab-bb62-8334d33aa724)
