### PR TITLE
doc: clarify bufferline-custom-areas

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -1125,25 +1125,36 @@ to be shown in a list of tables. For example:
         local info = #vim.diagnostic.get(0, {severity = seve.INFO})
         local hint = #vim.diagnostic.get(0, {severity = seve.HINT})
 
+        table.insert(result, {text = "", fg = "#EC5241"})
+        table.insert(result, {text = "", fg = "#EFB839"})
+        table.insert(result, {text = "", fg = "#A3BA5E"})
+        table.insert(result, {text = "", fg = "#7EA9A7"})
+
         if error ~= 0 then
-            table.insert(result, {text = "  " .. error, fg = "#EC5241"})
+            result[1].text = "  " .. error
         end
 
         if warning ~= 0 then
-            table.insert(result, {text = "  " .. warning, fg = "#EFB839"})
+            result[2].text = "  " .. warning
         end
 
         if hint ~= 0 then
-            table.insert(result, {text = "  " .. hint, fg = "#A3BA5E"})
+            result[3].text = "  " .. hint
         end
 
         if info ~= 0 then
-            table.insert(result, {text = "  " .. info, fg = "#7EA9A7"})
+            result[4].text = "  " .. info
         end
+
         return result
     end,
     }
 <
+
+
+This option will create a highlight groups for each table insert whether defined or not. For best experience,
+define all of your highlights if you are conditionally displaying text, otherwise your text may appear
+under unexpected highlight groups.
 
 Please note that this function will be called a lot and should be as inexpensive as possible so it does
 not block rendering the tabline.


### PR DESCRIPTION
Update text in `bufferline-custom-areas` section.

There is an unexplained issue or nuance with the given custom-area example. It is possible for errors to appear with warning/info/hint (or any diagnostic level under any highlight group) due to the way highlight groups are created.

Highlight groups are created on first pass [in L21 of method create_hl](https://github.com/akinsho/bufferline.nvim/blob/main/lua/bufferline/custom_area.lua#L16-L23) It is important to note that they are not unset.

For example, if the first diagnostic is a hint, then highlight group `BufferLineRightCustomAreaText1` will be the hint highlight group. Then, if you fix the hint and introduce an error diagnostic, it will appear with the hint highlighting.

One solution would be to unset highlight groups and then re-set them during method call. Destroying and creating the highlight groups each time tabline is rendered sounds like an expensive solution.

One workaround is to create the table entries with desired highlights so the `BufferLine[side]CustomAreaTest[number]` groups and insert the text if needed.

