### PR TITLE
fix: toggle tabline when tab added w/o new buffer

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -89,7 +89,8 @@ end
 --- If the item count has changed and the next tabline status is different then update it
 local function toggle_bufferline()
   if not config.options.auto_toggle_bufferline then return end
-  local item_count = config:is_tabline() and utils.get_tab_count() or utils.get_buf_count()
+  local item_count = config:is_tabline() and utils.get_tab_count()
+    or utils.get_buf_count() + (config.options.show_tab_indicators and (utils.get_tab_count() - 1) or 0)
   local status = (config.options.always_show_bufferline or item_count > 1) and 2 or 0
   if vim.o.showtabline ~= status then vim.o.showtabline = status end
 end


### PR DESCRIPTION
Currently, when a tab is created without a new buffer being added (e.g. `<C-W>s<C-W>T`), tabline visibility is not toggled. Fix this edge case so that the tabline is displayed when there are either >1 buffers or the tab indicators are enabled and there are >1 tabs.