### PR TITLE
Replace vim.tbl_add_reverse_lookup (deprecated in neovim v0.10)

### DIFF
--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -1,13 +1,14 @@
 local lazy = require("bufferline.lazy")
 local config = lazy.require("bufferline.config") ---@module "bufferline.config"
 local ui = lazy.require("bufferline.ui") ---@module "bufferline.ui"
+local utils = lazy.require("bufferline.utils") ---@module "bufferline.utils"
 
 local M = {}
 
 local fn = vim.fn
 local fmt = string.format
 
-local severity_name = vim.tbl_add_reverse_lookup({
+local severity_name = utils.tbl_add_reverse_lookup({
   [1] = "error",
   [2] = "warning",
   [3] = "info",

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -121,6 +121,22 @@ function M.tbl_reverse_lookup(tbl)
   return ret
 end
 
+--- creates a table containing the forward and reversed mapping from the provided
+--- table.
+--- similar to the now deprecated vim.tbl_add_reverse_lookup
+--- @generic K,V
+--- @param tbl table<K,V>
+--- @return table<V,K>
+function M.tbl_add_reverse_lookup(tbl)
+  local ret = {}
+  for k, v in pairs(tbl) do
+    ret[k] = v
+    ret[v] = k
+  end
+
+  return ret
+end
+
 M.path_sep = vim.fn.has("win32") == 1 and "\\" or "/"
 
 -- The provided api nvim_is_buf_loaded filters out all hidden buffers


### PR DESCRIPTION
**Problem**

After rebuilding neovim from from `master` (specifically, `06135cc21571b2707121e31176f544a0e0901e1d`), I'm noticing the following deprecation warning on startup:

<details>

```
vim.tbl_add_reverse_lookup is deprecated. :help deprecated
stack traceback:
        vim/shared.lua: in function 'tbl_add_reverse_lookup'
        ...nvim/lazy/bufferline.nvim/lua/bufferline/diagnostics.lua:10: in main chunk
        [C]: in function 'require'
        ...are/nvim/lazy/bufferline.nvim/lua/bufferline/buffers.lua:8: in main chunk
        [C]: in function 'require'
        .../share/nvim/lazy/bufferline.nvim/lua/bufferline/lazy.lua:11: in function '__index'
        ...local/share/nvim/lazy/bufferline.nvim/lua/bufferline.lua:56: in function <...local/share/nvim/lazy/bufferline.nvim/lua/buffer
line.lua:54>
```
</details>

Looking at neovim's deprecation help page, this function was deprecated as of neovim 0.10 and will not be replaced when it's removed.

**How does this fix?**

By crudely reimplementing `tbl_add_reverse_lookup` and using it in your diagnostics module.

**Reviewer notes**

I didn't take a super close look at the actual use of this reversed table (if you really need to have forward and also reverse mappings in the table).  I simply reimplemented what is now missing from the `vim` module.  If you don't need the mirrored mappings, `utils.tbl_reverse_lookup()` would suffice.

**Version**

neovim/neovim `06135cc21571b2707121e31176f544a0e0901e1d`:

```
NVIM v0.11.0-dev-6+g06135cc21
Build type: RelWithDebInfo
LuaJIT 2.1.1713484068
```