### PR TITLE
fix: vim.diagnostic.is_disabled() deprecation warning (deprecated in neovim 0.10.0)

### DIFF
--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -71,8 +71,7 @@ local get_diagnostics = {
     local results = {}
     local diagnostics = vim.diagnostic.get()
     for _, d in pairs(diagnostics) do
-      -- TODO remove is_disabled nil check when 0.9 is stable
-      if vim.diagnostic.is_disabled == nil or not vim.diagnostic.is_disabled(d.bufnr, d.namespace) then
+      if vim.diagnostic.is_enabled({ ns_id = d.namespace, bufnr = d.bufnr }) then
         if not results[d.bufnr] then results[d.bufnr] = {} end
         table.insert(results[d.bufnr], d)
       end


### PR DESCRIPTION
### Why this change?

Avoid getting deprecation warnings.

### What was changed?

- Replaced `vim.diagnostic.is_disabled()` with `vim.diagnostic.is_enabled()`.
- Removed nil check.
- Removed comment.

### Notes

This requires Neovim 0.10.0: https://neovim.io/doc/user/news-0.10.html


