### PR TITLE
fix: maintain backwards compatibility with neovim 0.9.x

### DIFF
--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -67,12 +67,21 @@ local function is_insert() -- insert or replace
   return mode == "i" or mode == "ic" or mode == "ix" or mode == "R" or mode == "Rc" or mode == "Rx"
 end
 
+local function diagnostic_is_enabled(d)
+  if vim.fn.has("nvim-0.10") == 1 then
+    return vim.diagnostic.is_enabled({ ns_id = d.namespace, bufnr = d.bufnr })
+  else
+    -- neovim 0.9.x
+    return not (vim.diagnostic.is_disabled and vim.diagnostic.is_disabled(d.bufnr, d.namespace))
+  end
+end
+
 local get_diagnostics = {
   nvim_lsp = function()
     local results = {}
     local diagnostics = vim.diagnostic.get()
     for _, d in pairs(diagnostics) do
-      if vim.diagnostic.is_enabled({ ns_id = d.namespace, bufnr = d.bufnr }) then
+      if diagnostic_is_enabled(d) then
         if not results[d.bufnr] then results[d.bufnr] = {} end
         table.insert(results[d.bufnr], d)
       end


### PR DESCRIPTION
### Why this change?

As mentioned by @folke in https://github.com/akinsho/bufferline.nvim/pull/907#issuecomment-2119309364, #907 breaks backwards compat with Neovim 0.9.x.

### What was changed?

- Add convenience function to hold the 0.10.0 and 0.9.x syntax for checking whether diagnostics are enabled or not.



