### PR TITLE
fix: don't reference unloaded buffers

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -145,8 +145,9 @@ M.path_sep = fn.has("win32") == 1 and "\\" or "/"
 --- @param buf_num integer
 function M.is_valid(buf_num)
   if not buf_num or buf_num < 1 then return false end
-  local exists = vim.api.nvim_buf_is_valid(buf_num)
-  return vim.bo[buf_num].buflisted and exists
+  local exists = vim.api.nvim_buf_is_loaded(buf_num)
+  if not exists then return false end
+  return vim.bo[buf_num].buflisted
 end
 
 ---@return integer


### PR DESCRIPTION
### Problem
Currently when checking if a buffer is valid, we use the function [nvim_buf_is_valid](https://neovim.io/doc/user/api.html#nvim_buf_is_valid()), however there is an edge case here described in the documentation where a buffer could have been unloaded, but still be "valid". If a buffer is unloaded and valid then referencing `buflisted` will result in a `(UNKNOWN PLUGIN): Error executing lua: attempt to call a number value` error.

### Solution
Instead of `nvim_buf_is_valid` we use [nvim_buf_is_loaded](https://neovim.io/doc/user/api.html#nvim_buf_is_loaded()) which checks both whether a buffer is valid _and_ loaded. This way we never attempt to reference `buflisted` of unloaded or invalid buffers.

This PR should at least partially address #869. Applying the patch removes these errors for my config when invoking Neovim via `nvim .`. Because this error is so generic, it's possible that there could be more than one cause.