### PR TITLE
fix: UNKNOWN PLUGIN error resulting from unloaded buffers

### DIFF
--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -51,7 +51,7 @@ end
 ---@return bufferline.Buffer[]
 function M.get_components(state)
   local options = config.options
-  local buf_nums = utils.get_valid_buffers()
+  local buf_nums = vim.tbl_map(function(buf) return buf.bufnr end, utils.get_valid_buffers())
   local filter = options.custom_filter
   buf_nums = filter and apply_buffer_filter(buf_nums, filter) or buf_nums
   buf_nums = get_updated_buffers(buf_nums, state.custom_sort)

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -51,7 +51,7 @@ end
 ---@return bufferline.Buffer[]
 function M.get_components(state)
   local options = config.options
-  local buf_nums = vim.tbl_map(function(buf) return buf.bufnr end, utils.get_valid_buffers())
+  local buf_nums = utils.get_valid_buffers()
   local filter = options.custom_filter
   buf_nums = filter and apply_buffer_filter(buf_nums, filter) or buf_nums
   buf_nums = get_updated_buffers(buf_nums, state.custom_sort)

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -141,19 +141,20 @@ end
 
 M.path_sep = fn.has("win32") == 1 and "\\" or "/"
 
--- The provided api nvim_is_buf_loaded filters out all hidden buffers
---- @param buf_num integer
-function M.is_valid(buf_num)
-  if not buf_num or buf_num < 1 then return false end
-  local exists = vim.api.nvim_buf_is_valid(buf_num)
-  return exists and vim.bo[buf_num].buflisted
+-- The provided api nvim_is_buf_valid filters out all invalid or unlisted buffers
+--- @param buf table
+function M.is_valid(buf)
+  if not buf.bufnr or buf.bufnr < 1 then return false end
+  local valid = vim.api.nvim_buf_is_valid(buf.bufnr)
+  if not valid then return false end
+  return buf.listed == 1
 end
 
 ---@return integer
 function M.get_buf_count() return #fn.getbufinfo({ buflisted = 1 }) end
 
----@return integer[]
-function M.get_valid_buffers() return vim.tbl_filter(M.is_valid, vim.api.nvim_list_bufs()) end
+---@return table[]
+function M.get_valid_buffers() return vim.tbl_filter(M.is_valid, vim.fn.getbufinfo()) end
 
 ---@return integer
 function M.get_tab_count() return #fn.gettabinfo() end

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -153,8 +153,15 @@ end
 ---@return integer
 function M.get_buf_count() return #fn.getbufinfo({ buflisted = 1 }) end
 
----@return table[]
-function M.get_valid_buffers() return vim.tbl_filter(M.is_valid, vim.fn.getbufinfo()) end
+---@return integer[]
+function M.get_valid_buffers()
+  local bufs = vim.fn.getbufinfo()
+  local valid_bufs = {}
+  for _, buf in ipairs(bufs) do
+    if M.is_valid(buf) then table.insert(valid_bufs, buf.bufnr) end
+  end
+  return valid_bufs
+end
 
 ---@return integer
 function M.get_tab_count() return #fn.gettabinfo() end


### PR DESCRIPTION
### Problem
Currently when checking if a buffer is valid, we use the function [nvim_buf_is_valid](https://neovim.io/doc/user/api.html#nvim_buf_is_valid()), however there is an edge case here described in the documentation where a buffer could have been unloaded, but still be "valid". If a buffer is unloaded and valid then referencing `buf.buflisted` _could_ result in a `(UNKNOWN PLUGIN): Error executing lua: attempt to call a number value` error. I believe this issue may be a bug in Neovim itself and I have attempted to get more clarity on this [here](https://github.com/neovim/neovim/issues/10070#issuecomment-2180146301).

This issue reproduced in my config when `bufferline` attempted to reference the `buf.buflisted` property of unloaded `nvim-tree` buffer.

Note: A previous attempt at this fix (#928) attempted to address the issue by changing the call to `nvim_buf_is_valid` to `nvim_buf_is_loaded`. While this solves the problem defined above, it had the side effect of breaking users of various session plugins. This is because session plugins utilize unloaded buffers which are also listed (i.e. calling `.buflisted` on these buffers returns `1`).

### Solution
Instead of utilizing `buf.buflisted`, which can potentially result in `UNKNOWN PLUGIN` errors for certain unloaded buffers, we utilize `vim.fn.getbufinfo` which returns a list of info tables for all buffers. This table contains a property `listed` which is `0` if the buffer is unlisted, and `1` if the buffer is listed. This allows us to check whether the unloaded buffer is listed, without referencing `buf.buflisted` directly.

I have locally verified that this solution both resolves the `UNKNOWN PLUGIN` errors, and supports loading "hidden" session buffers via the [posession](https://github.com/jedrzejboczar/possession.nvim) plugin.