### PR TITLE
feat(diag): add `diagnostics_update_on_event` option

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -101,6 +101,7 @@ The available configuration are:
             tab_size = 18,
             diagnostics = false | "nvim_lsp" | "coc",
             diagnostics_update_in_insert = false,
+            diagnostics_update_on_event = true, -- use nvim's diagnostic handler
             -- The diagnostics indicator can be set to nil to keep the buffer name highlight but delete the highlighting
             diagnostics_indicator = function(count, level, diagnostics_dict, context)
                 return "("..count..")"

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -100,7 +100,7 @@ The available configuration are:
             truncate_names = true, -- whether or not tab names should be truncated
             tab_size = 18,
             diagnostics = false | "nvim_lsp" | "coc",
-            diagnostics_update_in_insert = false,
+            diagnostics_update_in_insert = false, -- only applies to coc
             diagnostics_update_on_event = true, -- use nvim's diagnostic handler
             -- The diagnostics indicator can be set to nil to keep the buffer name highlight but delete the highlighting
             diagnostics_indicator = function(count, level, diagnostics_dict, context)

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -181,6 +181,15 @@ local function setup_commands()
   })
 end
 
+local function setup_diagnostic_handler(preferences)
+  if preferences.options.diagnostics == "nvim_lsp" and preferences.options.diagnostics_update_on_event then
+    vim.diagnostic.handlers["bufferline"] = {
+      show = function() ui.refresh() end,
+      hide = function() ui.refresh() end,
+    }
+  end
+end
+
 ---@param conf bufferline.UserConfig?
 function M.setup(conf)
   conf = conf or {}
@@ -192,6 +201,7 @@ function M.setup(conf)
   hover.setup(preferences)
   setup_commands()
   setup_autocommands(preferences)
+  setup_diagnostic_handler(preferences)
   vim.o.tabline = "%!v:lua.nvim_bufferline()"
   toggle_bufferline()
 end

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -62,6 +62,18 @@ local function validate_user_options(options)
     local item = deprecations[key]
     if item then vim.schedule(function() vim.deprecate(item.name, item.alternative, item.version, "bufferline") end) end
   end
+  if options.diagnostics == "nvim_lsp" and options.diagnostics_update_in_insert then
+    vim.schedule(
+      function()
+        vim.deprecate(
+          "diagnostics_update_in_insert",
+          "vim.diagnostic.config { update_in_insert = true }",
+          "4.6.3",
+          "bufferline"
+        )
+      end
+    )
+  end
 end
 
 ---@param options bufferline.Options

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -657,6 +657,7 @@ local function get_defaults()
     diagnostics = false,
     diagnostics_indicator = nil,
     diagnostics_update_in_insert = true,
+    diagnostics_update_on_event = true,
     offsets = {},
     groups = { items = {}, options = { toggle_hidden_on_enter = true } },
     hover = { enabled = false, reveal = {}, delay = 200 },

--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -144,7 +144,9 @@ end
 ---@param opts table
 function M.get(opts)
   if is_disabled(opts.diagnostics) then return setmetatable({}, mt) end
-  if is_insert() and not opts.diagnostics_update_in_insert then return setmetatable(last_diagnostics_result, mt) end
+  local update_nvim = opts.diagnostics == "nvim_lsp" and vim.diagnostic.config().update_in_insert
+  local update_coc = opts.diagnostics == "coc" and opts.diagnostics_update_in_insert
+  if is_insert() and not update_nvim and not update_coc then return setmetatable(last_diagnostics_result, mt) end
   local diagnostics = get_diagnostics[opts.diagnostics]()
   local result = {}
   for buf_num, items in pairs(diagnostics) do

--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -62,6 +62,7 @@
 ---@field public diagnostics? boolean | 'nvim_lsp' | 'coc'
 ---@field public diagnostics_indicator? bufferline.DiagnosticIndicator
 ---@field public diagnostics_update_in_insert? boolean
+---@field public diagnostics_update_on_event? boolean
 ---@field public offsets? table[]
 ---@field public groups? bufferline.GroupOpts
 ---@field public themable? boolean


### PR DESCRIPTION
### About this PR

Closes #923.

This change makes the ui refresh whenever nvim reports a diagnostic change.

Demo: bufferline diagnostics are up to date


https://github.com/akinsho/bufferline.nvim/assets/29818440/9a9112ab-c210-4340-8be4-5fd89b46b75d



### Possible improvements for later

When nvim calls our diagnostic handler, we could get extra information about the change, for example the buffer that the change occurred in, all the details about the diagnostics in that buffer and options like `update_in_insert` (configured via `vim.diagnostic.config`). We could use these to replace `vim.diagnostic.get` call (possibly improving performance) and deprecate the bufferline option `diagnostic_update_in_insert`. However it would increase the complexity since we want to keep support for coc, so I decided not to do these changes.