### PR TITLE
feat(tabpages): pass the bufnr to the `name_formatter`

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -91,7 +91,7 @@ The available configuration are:
             name_formatter = function(buf)  -- buf contains:
                   -- name                | str        | the basename of the active file
                   -- path                | str        | the full path of the active file
-                  -- bufnr (buffer only) | int        | the number of the active buffer
+                  -- bufnr               | int        | the number of the active buffer
                   -- buffers (tabs only) | table(int) | the numbers of the buffers in the tab
                   -- tabnr (tabs only)   | int        | the "handle" of the tab, can be converted to its ordinal number using: `vim.api.nvim_tabpage_get_number(buf.tabnr)`
             end,

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -121,6 +121,7 @@ function Tabpage:new(tab)
     tab.name = tab.name_formatter({
       name = tab.name,
       path = tab.path,
+      bufnr = tab.buf,
       tabnr = tab.id,
       buffers = tab.buffers,
     }) or tab.name


### PR DESCRIPTION
There seems to be no limitation to making `tabs` mode have access to `bufnr`.