### PR TITLE
docs: fix broken/buggy lua examples

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -166,7 +166,9 @@ The available configuration are:
             },
             sort_by = 'insert_after_current' |'insert_at_end' | 'id' | 'extension' | 'relative_directory' | 'directory' | 'tabs' | function(buffer_a, buffer_b)
                 -- add custom logic
-                return buffer_a.modified > buffer_b.modified
+                local modified_a = vim.fn.getftime(buffer_a.path)
+                local modified_b = vim.fn.getftime(buffer_b.path)
+                return modified_a > modified_b
             end
         }
     }
@@ -483,7 +485,9 @@ are available to use using >lua
     sort_by = function(buffer_a, buffer_b)
         print(vim.inspect(buffer_a))
         -- add custom logic
-        return buffer_a.modified > buffer_b.modified
+        local modified_a = vim.fn.getftime(buffer_a.path)
+        local modified_b = vim.fn.getftime(buffer_b.path)
+        return modified_a > modified_b
     end
 <
 

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -573,7 +573,7 @@ A user can also execute arbitrary functions against a buffer using the
     function _G.bdel(num)
         require('bufferline').exec(num, function(buf, visible_buffers)
             vim.cmd('bdelete '..buf.id)
-        end
+        end)
     end
 
     vim.cmd [[

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -1126,19 +1126,19 @@ to be shown in a list of tables. For example:
         local hint = #vim.diagnostic.get(0, {severity = seve.HINT})
 
         if error ~= 0 then
-            table.insert(result, {text = "  " .. error, fg = "#EC5241"})
+            table.insert(result, {text = "  " .. error, link = "DiagnosticError"})
         end
 
         if warning ~= 0 then
-            table.insert(result, {text = "  " .. warning, fg = "#EFB839"})
+            table.insert(result, {text = "  " .. warning, link = "DiagnosticWarn"})
         end
 
         if hint ~= 0 then
-            table.insert(result, {text = "  " .. hint, fg = "#A3BA5E"})
+            table.insert(result, {text = "  " .. hint, link = "DiagnosticHint"})
         end
 
         if info ~= 0 then
-            table.insert(result, {text = "  " .. info, fg = "#7EA9A7"})
+            table.insert(result, {text = "  " .. info, link = "DiagnosticInfo"})
         end
         return result
     end,


### PR DESCRIPTION
Breakdown of https://github.com/akinsho/bufferline.nvim/pull/922. This PR fixes lua codes that cause runtime errors (a096678a84fe5e96e36ed7e817e80bf8a56e7740 and 5e7687afc9075a3213c9b7759f2bc63cab74ee12) and has buggy behaviours (9fedfd15a6bb4683dc894e8d8e4fa98489fea2fa), see the detailed commit message for more info.

These are mostly notes to myself how does it compare to previous PR:
- cherry-picked 698b202
- cherry-picked c0c9b72 without stylistic changes
- cherry-picked 8bd95fc without the extra print (currently on line 168 it doesn't have print buffer_a, on 486 it has)

Follow-up PRs (I might wait with these until this is merged to avoid merge conflicts):
- [ ] update diagnostic symbols and consistent booleans (needs discussion)
- [ ] formatting and stylistic changes: indent size, single/double quotes...

cc @akinsho 