### PR TITLE
feat(ui): pass formatter opts to icon fetcher as well

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -136,7 +136,7 @@ The available configuration are:
             },
             color_icons = true | false, -- whether or not to add the filetype icon highlights
             get_element_icon = function(element)
-              -- element consists of {filetype: string, path: string, extension: string, directory: string}
+              -- element consists of {filetype: string, extension: string, directory: string, type:string?}, and all the properties same as the `name_formatter` function
               -- This can be used to change how bufferline fetches the icon
               -- for an element e.g. a buffer or a tab.
               -- e.g.

--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -19,6 +19,8 @@
 ---@alias bufferline.DiagnosticIndicator fun(count: number, level: string, errors: table<string, any>, ctx: table<string, any>): string
 
 ---@alias bufferline.HoverOptions {reveal: string[], delay: integer, enabled: boolean}
+---@alias bufferline.BufFormatterOpts {name: string, path: string, bufnr: number}
+---@alias bufferline.TabFormatterOpts {buffers: number[], tabnr: number} | bufferline.BufFormatterOpts
 ---@alias bufferline.IconFetcherOpts {directory: boolean, path: string, extension: string, filetype: string?}
 
 ---@class bufferline.Options
@@ -136,7 +138,7 @@
 ---@class bufferline.Buffer
 ---@field public extension string the file extension
 ---@field public path string the full path to the file
----@field public name_formatter function? dictates how the name should be shown
+---@field public name_formatter fun(opts: bufferline.BufFormatterOpts): string?
 ---@field public id integer the buffer number
 ---@field public name string the visible name for the file
 ---@field public filename string


### PR DESCRIPTION
When a user customized the name by `name_formatter`, they would customize the icon too. I think it should be better to make them have the same arguments, but considering changing the arguments would be a breaking change, I recommend adding all the `name_formatter` properties to `get_element_icon`.

In my usage, I use the tab mode of bufferline, I don't want bufferline to show the name of buffers which has a special buftype when there is a normal buffer that exists in the tabpage.