### PR TITLE
docs: nerdfonts symbols improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ In order to customise the appearance of the diagnostic count you can pass a cust
 --- this should return a string
 --- Don't get too fancy as this function will be executed a lot
 diagnostics_indicator = function(count, level, diagnostics_dict, context)
-  local icon = level:match("error") and " " or " "
+  local icon = level:match("error") and " " or " "
   return " " .. icon .. count
 end
 
@@ -194,7 +194,7 @@ diagnostics_indicator = function(count, level, diagnostics_dict, context)
   local s = " "
   for e, n in pairs(diagnostics_dict) do
     local sym = e == "error" and " "
-      or (e == "warning" and " " or "" )
+      or (e == "warning" and " " or "" )
     s = s .. n .. sym
   end
   return s

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ diagnostics_indicator = function(count, level, diagnostics_dict, context)
   local s = " "
   for e, n in pairs(diagnostics_dict) do
     local sym = e == "error" and " "
-      or (e == "warning" and " " or "" )
+      or (e == "warning" and " " or " ")
     s = s .. n .. sym
   end
   return s

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -316,7 +316,7 @@ a custom function in your setup.
     --- this should return a string
     --- Don't get too fancy as this function will be executed a lot
     diagnostics_indicator = function(count, level)
-        local icon = level:match("error") and " " or ""
+        local icon = level:match("error") and " " or ""
         return " " .. icon .. count
     end
 <
@@ -439,7 +439,7 @@ to other groups e.g.
     options = {
         groups = {
             items = {
-                require('bufferline.groups').builtin.pinned:with({ icon = "" })
+                require('bufferline.groups').builtin.pinned:with({ icon = "󰐃" })
                 ... -- other items
             }
         }
@@ -1131,19 +1131,19 @@ to be shown in a list of tables. For example:
         local hint = #vim.diagnostic.get(0, {severity = seve.HINT})
 
         if error ~= 0 then
-            table.insert(result, {text = "  " .. error, link = "DiagnosticError"})
+            table.insert(result, {text = "  " .. error, link = "DiagnosticError"})
         end
 
         if warning ~= 0 then
-            table.insert(result, {text = "  " .. warning, link = "DiagnosticWarn"})
+            table.insert(result, {text = "  " .. warning, link = "DiagnosticWarn"})
         end
 
         if hint ~= 0 then
-            table.insert(result, {text = "  " .. hint, link = "DiagnosticHint"})
+            table.insert(result, {text = "  " .. hint, link = "DiagnosticHint"})
         end
 
         if info ~= 0 then
-            table.insert(result, {text = "  " .. info, link = "DiagnosticInfo"})
+            table.insert(result, {text = "  " .. info, link = "DiagnosticInfo"})
         end
         return result
     end,

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -80,10 +80,10 @@ The available configuration are:
                 style = 'icon' | 'underline' | 'none',
             },
             buffer_close_icon = '󰅖',
-            modified_icon = '●',
-            close_icon = '',
-            left_trunc_marker = '',
-            right_trunc_marker = '',
+            modified_icon = '● ',
+            close_icon = ' ',
+            left_trunc_marker = ' ',
+            right_trunc_marker = ' ',
             --- name_formatter can be used to change the buffer's label in the bufferline.
             --- Please note some names can/will break the
             --- bufferline so use this at your discretion knowing that it has
@@ -316,7 +316,7 @@ a custom function in your setup.
     --- this should return a string
     --- Don't get too fancy as this function will be executed a lot
     diagnostics_indicator = function(count, level)
-        local icon = level:match("error") and " " or ""
+        local icon = level:match("error") and " " or " "
         return " " .. icon .. count
     end
 <
@@ -337,7 +337,7 @@ current buffer and only have them appear for other buffers.
             return ''
         end
 
-        return ''
+        return ' '
     end
 <
 
@@ -361,7 +361,7 @@ In order to group buffers specify a list of groups in your config e.g.
         name = "Tests", -- Mandatory
         highlight = {underline = true, sp = "blue"}, -- Optional
         priority = 2, -- determines where it will appear relative to other groups (Optional)
-        icon = "", -- Optional
+        icon = " ", -- Optional
         matcher = function(buf) -- Mandatory
           return buf.filename:match('%_test') or buf.filename:match('%_spec')
         end,
@@ -439,7 +439,7 @@ to other groups e.g.
     options = {
         groups = {
             items = {
-                require('bufferline.groups').builtin.pinned:with({ icon = "󰐃" })
+                require('bufferline.groups').builtin.pinned:with({ icon = "󰐃 " })
                 ... -- other items
             }
         }


### PR DESCRIPTION
Breakdown of #922.

Some nerdfonts symbols got removed, and some just had a different style (eg. filled vs hollow), I decided to go with filled. Github doesn't render nerdfonts symbols, here's how they look: (351763c)
![bufferline-nerdfonts-update](https://github.com/user-attachments/assets/bfb148c0-dd8f-4edf-952a-5dd6f1261b6f)

cc @akinsho 