### PR TITLE
fix(pinned): buffer does not exist after switching sessions

### DIFF
--- a/lua/bufferline/groups.lua
+++ b/lua/bufferline/groups.lua
@@ -150,7 +150,9 @@ local group_state = {
 local function persist_pinned_buffers()
   local pinned = {}
   for buf, group in pairs(group_state.manual_groupings) do
-    if group == PINNED_ID then table.insert(pinned, api.nvim_buf_get_name(buf)) end
+    if group == PINNED_ID and vim.fn.bufexists(buf) == 1 then
+        table.insert(pinned, api.nvim_buf_get_name(buf))
+    end
   end
 
   if #pinned == 0 then


### PR DESCRIPTION
Hello,

I've been experimenting with pinned buffers and sessions, and I encountered an error.

**Steps to reproduce:**

- Pin a buffer
- Restore a Vim session
- Pin another buffer

**Error Message:**

```
Error executing Lua callback: ...hare/nvim/lazy/bufferline.nvim/lua/bufferline/groups.lua:154: Invalid buffer id: 3
stack traceback:
        [C]: in function 'nvim_buf_get_name'
        ...hare/nvim/lazy/bufferline.nvim/lua/bufferline/groups.lua:154: in function 'persist_pinned_buffers'
        ...hare/nvim/lazy/bufferline.nvim/lua/bufferline/groups.lua:323: in function 'add_element'
        ...hare/nvim/lazy/bufferline.nvim/lua/bufferline/groups.lua:486: in function 'toggle_pin'
        ...local/share/nvim/lazy/bufferline.nvim/lua/bufferline.lua:172: in function <...local/share/nvim/lazy/bufferline.nvim/lua/bufferline.lua:172>
```

**Video:**

[bufferline_error.webm](https://github.com/user-attachments/assets/2cb8a6b1-31af-4bcb-ad43-2d10bedbdd04)

---

I believe a possible solution could be updating the buffer IDs, but I wanted to get another opinion before spending more time on it. My current fix only suppresses the error messages, but the incorrect buffer IDs are still in memory. Perhaps I'm overlooking something.