### PR TITLE
Allow different configuration for BufferLinePick

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -170,7 +170,10 @@ The available configuration are:
                 local modified_a = vim.fn.getftime(buffer_a.path)
                 local modified_b = vim.fn.getftime(buffer_b.path)
                 return modified_a > modified_b
-            end
+            end,
+            pick = {
+              alphabet = "abcdefghijklmopqrstuvwxyzABCDEFGHIJKLMOPQRSTUVWXYZ1234567890",
+            },
         }
     }
 <
@@ -657,6 +660,19 @@ this can also be mapped to something like
 >vim
   nnoremap <silent> gD :BufferLinePickClose<CR>
 >
+
+You can configure the characters used for selecting buffers using the 
+`pick.alphabet` option. By default, both uppercase and lowercase 
+alphanumeric characters are used.
+>lua
+    options = {
+        pick = {
+            alphabet = "abcdefghijklmopqrstuvwxyz"
+        }
+    }
+<
+
+With the configuration above, bufferline will only use lowercase letters.
 
 ==============================================================================
 MOUSE ACTIONS                                     *bufferline-mouse-actions*

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -674,6 +674,9 @@ local function get_defaults()
     groups = { items = {}, options = { toggle_hidden_on_enter = true } },
     hover = { enabled = false, reveal = {}, delay = 200 },
     debug = { logging = false },
+    pick = {
+      alphabet = "abcdefghijklmopqrstuvwxyzABCDEFGHIJKLMOPQRSTUVWXYZ1234567890",
+    },
   }
   return { options = opts, highlights = derive_colors(opts.style_preset) }
 end

--- a/lua/bufferline/pick.lua
+++ b/lua/bufferline/pick.lua
@@ -10,8 +10,6 @@ local strwidth = vim.api.nvim_strwidth
 
 M.current = {}
 
-local valid = "abcdefghijklmopqrstuvwxyzABCDEFGHIJKLMOPQRSTUVWXYZ"
-
 function M.reset() M.current = {} end
 
 -- Prompts user to select a buffer then applies a function to the buffer
@@ -35,15 +33,17 @@ end
 ---@param element bufferline.Tab|bufferline.Buffer
 ---@return string?
 function M.get(element)
-  local first_letter = element.name:sub(1, 1)
-  -- should only match alphanumeric characters
-  local invalid_char = first_letter:match("[^%w]")
+  local valid_alphabet = config.options.pick.alphabet
 
-  if not M.current[first_letter] and not invalid_char then
+  local first_letter = element.name:sub(1, 1)
+
+  local is_valid_char = first_letter:match("[" .. valid_alphabet .. "]")
+
+  if not M.current[first_letter] and is_valid_char then
     M.current[first_letter] = element.id
     return first_letter
   end
-  for letter in valid:gmatch(".") do
+  for letter in valid_alphabet:gmatch(".") do
     if not M.current[letter] then
       M.current[letter] = element.id
       return letter


### PR DESCRIPTION
I've added some new options to allow me to only use my homerow keys to switch between buffers. I think it might be interesting for other people too, so let me know if you're interested in merging it and/or if it needs any modifications. 

The default behavior is still the same.

