### PR TITLE
Do not load web icons if not needed

### DIFF
--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -217,6 +217,9 @@ function M.get_icon(opts)
     if icon then return icon, hl end
   end
 
+  if not config.show_buffer_icons then
+    return "", ""
+  end
   local loaded, webdev_icons = pcall(require, "nvim-web-devicons")
   if opts.directory then
     local hl = loaded and "DevIconDefault" or nil


### PR DESCRIPTION
We can set `show_buffer_icons` to false to disable web icons, but the icons is still being loaded during initialization. This is costly(loading the icon package needs ~ 20ms while the bufferline package itself cost just a few ms init time) and
unnecessary when user doesn't need the icons anyways. 

before `using :Lazy profile`

```
      ➜  bufferline.nvim 23.35ms
        ★  nvim-web-devicons 20.24ms
          ‒  nvim-web-devicons/plugin/nvim-web-devicons.vim 0.06ms

```

after

```
      ➜  bufferline.nvim 5.44ms
```